### PR TITLE
feat: 添加跨服务器属性系统

### DIFF
--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/Broker.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/Broker.java
@@ -8,6 +8,7 @@ import net.afyer.afybroker.core.BrokerClientInfo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
@@ -129,6 +130,64 @@ public final class Broker {
      */
     public static <T> T getService(Class<T> serviceInterface, String... tags) {
         return client.getService(serviceInterface, tags);
+    }
+
+    // ==================== 属性操作 ====================
+
+    /**
+     * 设置服务器全局属性
+     */
+    public static <T> void setServerAttribute(String key, T value) throws RemotingException, InterruptedException {
+        client.setServerAttribute(key, value);
+    }
+
+    /**
+     * 获取服务器全局属性
+     */
+    public static <T> T getServerAttribute(String key) throws RemotingException, InterruptedException {
+        return client.getServerAttribute(key);
+    }
+
+    /**
+     * 移除服务器全局属性
+     */
+    public static void removeServerAttribute(String key) throws RemotingException, InterruptedException {
+        client.removeServerAttribute(key);
+    }
+
+    /**
+     * 判断是否存在服务器全局属性
+     */
+    public static boolean hasServerAttribute(String key) throws RemotingException, InterruptedException {
+        return client.hasServerAttribute(key);
+    }
+
+    /**
+     * 设置玩家属性
+     */
+    public static <T> void setPlayerAttribute(UUID uniqueId, String key, T value) throws RemotingException, InterruptedException {
+        client.setPlayerAttribute(uniqueId, key, value);
+    }
+
+    /**
+     * 获取玩家属性
+     */
+    public static <T> T getPlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
+        return client.getPlayerAttribute(uniqueId, key);
+    }
+
+    /**
+     * 移除玩家属性
+     */
+    public static void removePlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
+        client.removePlayerAttribute(uniqueId, key);
+    }
+
+    /**
+     * 判断是否存在玩家属性
+     */
+    public static boolean hasPlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
+        return client.hasPlayerAttribute(uniqueId, key);
     }
 
     /**

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClient.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClient.java
@@ -2,9 +2,11 @@ package net.afyer.afybroker.client;
 
 import com.alipay.remoting.InvokeCallback;
 import com.alipay.remoting.LifeCycleException;
+import com.alipay.remoting.config.ConfigManager;
 import com.alipay.remoting.exception.RemotingException;
 import com.alipay.remoting.rpc.RpcClient;
 import com.alipay.remoting.rpc.RpcResponseFuture;
+import com.alipay.remoting.serialization.Serializer;
 import com.alipay.remoting.serialization.SerializerManager;
 import net.afyer.afybroker.client.aware.BrokerClientAware;
 import net.afyer.afybroker.client.preprocessor.BrokerInvocationContext;
@@ -13,12 +15,14 @@ import net.afyer.afybroker.client.preprocessor.PreprocessorException;
 import net.afyer.afybroker.client.service.BrokerServiceProxyFactory;
 import net.afyer.afybroker.client.service.BrokerServiceRegistry;
 import net.afyer.afybroker.core.BrokerClientInfo;
+import net.afyer.afybroker.core.message.AttributeMessage;
 import net.afyer.afybroker.core.serializer.HessianSerializer;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @author Nipuru
@@ -172,6 +176,116 @@ public class BrokerClient {
                 preprocessor.preprocess(context);
             }
         }
+    }
+
+    // ==================== 属性操作 ====================
+
+    private Serializer getSerializer() {
+        return SerializerManager.getSerializer(ConfigManager.serializer());
+    }
+
+    /**
+     * 设置服务器全局属性
+     */
+    public <T> void setServerAttribute(String key, T value) throws RemotingException, InterruptedException {
+        Serializer serializer = getSerializer();
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_SET)
+                .setScope(AttributeMessage.SCOPE_SERVER)
+                .setKey(key)
+                .setValue(serializer.serialize(value));
+        invokeSync(msg);
+    }
+
+    /**
+     * 获取服务器全局属性
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getServerAttribute(String key) throws RemotingException, InterruptedException {
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_GET)
+                .setScope(AttributeMessage.SCOPE_SERVER)
+                .setKey(key);
+        byte[] result = invokeSync(msg);
+        if (result == null) return null;
+        return (T) getSerializer().deserialize(result, Object.class.getName());
+    }
+
+    /**
+     * 移除服务器全局属性
+     */
+    public void removeServerAttribute(String key) throws RemotingException, InterruptedException {
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_REMOVE)
+                .setScope(AttributeMessage.SCOPE_SERVER)
+                .setKey(key);
+        invokeSync(msg);
+    }
+
+    /**
+     * 判断是否存在服务器全局属性
+     */
+    public boolean hasServerAttribute(String key) throws RemotingException, InterruptedException {
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_HAS)
+                .setScope(AttributeMessage.SCOPE_SERVER)
+                .setKey(key);
+        Boolean result = invokeSync(msg);
+        return result != null && result;
+    }
+
+    /**
+     * 设置玩家属性
+     */
+    public <T> void setPlayerAttribute(UUID uniqueId, String key, T value) throws RemotingException, InterruptedException {
+        Serializer serializer = getSerializer();
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_SET)
+                .setScope(AttributeMessage.SCOPE_PLAYER)
+                .setUniqueId(uniqueId)
+                .setKey(key)
+                .setValue(serializer.serialize(value));
+        invokeSync(msg);
+    }
+
+    /**
+     * 获取玩家属性
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getPlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_GET)
+                .setScope(AttributeMessage.SCOPE_PLAYER)
+                .setUniqueId(uniqueId)
+                .setKey(key);
+        byte[] result = invokeSync(msg);
+        if (result == null) return null;
+        return (T) getSerializer().deserialize(result, Object.class.getName());
+    }
+
+    /**
+     * 移除玩家属性
+     */
+    public void removePlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_REMOVE)
+                .setScope(AttributeMessage.SCOPE_PLAYER)
+                .setUniqueId(uniqueId)
+                .setKey(key);
+        invokeSync(msg);
+    }
+
+    /**
+     * 判断是否存在玩家属性
+     */
+    public boolean hasPlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
+        AttributeMessage msg = new AttributeMessage()
+                .setAction(AttributeMessage.ACTION_HAS)
+                .setScope(AttributeMessage.SCOPE_PLAYER)
+                .setUniqueId(uniqueId)
+                .setKey(key);
+        Boolean result = invokeSync(msg);
+        return result != null && result;
     }
 
     public void printInformation(Logger logger) {

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/Attributable.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/Attributable.java
@@ -1,0 +1,47 @@
+package net.afyer.afybroker.core;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * 可属性化接口，提供基于键值对的属性存储能力
+ * 值以 byte[] 形式存储（Hessian 序列化）
+ *
+ * @author Conan-Wen
+ * @since 2026/3/22
+ */
+public interface Attributable {
+
+    /**
+     * 设置属性
+     *
+     * @param key   属性键
+     * @param value 属性值（Hessian 序列化后的字节数组）
+     */
+    void setAttribute(String key, byte[] value);
+
+    /**
+     * 获取属性
+     *
+     * @param key 属性键
+     * @return 属性值，不存在则返回 null
+     */
+    @Nullable
+    byte[] getAttribute(String key);
+
+    /**
+     * 判断是否存在指定属性
+     *
+     * @param key 属性键
+     * @return 是否存在
+     */
+    boolean hasAttribute(String key);
+
+    /**
+     * 移除属性
+     *
+     * @param key 属性键
+     * @return 被移除的属性值，不存在则返回 null
+     */
+    @Nullable
+    byte[] removeAttribute(String key);
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/message/AttributeMessage.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/message/AttributeMessage.java
@@ -1,0 +1,97 @@
+package net.afyer.afybroker.core.message;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.UUID;
+
+/**
+ * 属性操作统一消息
+ * 通过 action 和 scope 字段区分不同操作类型和作用域
+ *
+ * @author Conan-Wen
+ * @since 2026/3/22
+ */
+public class AttributeMessage implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /** 操作类型常量 */
+    public static final int ACTION_SET = 0;
+    public static final int ACTION_GET = 1;
+    public static final int ACTION_REMOVE = 2;
+    public static final int ACTION_HAS = 3;
+
+    /** 作用域常量 */
+    public static final int SCOPE_SERVER = 0;
+    public static final int SCOPE_PLAYER = 1;
+
+    /** 操作类型 */
+    private int action;
+
+    /** 作用域 */
+    private int scope;
+
+    /** 属性键 */
+    private String key;
+
+    /** 属性值（Hessian 序列化后的字节数组，仅 SET 时使用） */
+    private byte[] value;
+
+    /** 玩家UUID（仅 SCOPE_PLAYER 时使用） */
+    private UUID uniqueId;
+
+    public int getAction() {
+        return action;
+    }
+
+    public AttributeMessage setAction(int action) {
+        this.action = action;
+        return this;
+    }
+
+    public int getScope() {
+        return scope;
+    }
+
+    public AttributeMessage setScope(int scope) {
+        this.scope = scope;
+        return this;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public AttributeMessage setKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public byte[] getValue() {
+        return value;
+    }
+
+    public AttributeMessage setValue(byte[] value) {
+        this.value = value;
+        return this;
+    }
+
+    public UUID getUniqueId() {
+        return uniqueId;
+    }
+
+    public AttributeMessage setUniqueId(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "AttributeMessage{" +
+                "action=" + action +
+                ", scope=" + scope +
+                ", key='" + key + '\'' +
+                ", value=" + Arrays.toString(value) +
+                ", uniqueId=" + uniqueId +
+                '}';
+    }
+}

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/Broker.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/Broker.java
@@ -116,4 +116,35 @@ public class Broker {
     public static File getPluginsFolder() {
         return server.getPluginsFolder();
     }
+
+    // ==================== 属性操作 ====================
+
+    /**
+     * 设置服务器全局属性
+     */
+    public static void setServerAttribute(String key, byte[] value) {
+        server.setAttribute(key, value);
+    }
+
+    /**
+     * 获取服务器全局属性
+     */
+    @Nullable
+    public static byte[] getServerAttribute(String key) {
+        return server.getAttribute(key);
+    }
+
+    /**
+     * 移除服务器全局属性
+     */
+    public static void removeServerAttribute(String key) {
+        server.removeAttribute(key);
+    }
+
+    /**
+     * 判断是否存在服务器全局属性
+     */
+    public static boolean hasServerAttribute(String key) {
+        return server.hasAttribute(key);
+    }
 }

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServer.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServer.java
@@ -7,6 +7,7 @@ import com.alipay.remoting.rpc.RpcServer;
 import com.alipay.remoting.rpc.protocol.UserProcessor;
 import com.alipay.remoting.serialization.SerializerManager;
 import com.google.common.collect.Lists;
+import net.afyer.afybroker.core.Attributable;
 import net.afyer.afybroker.core.serializer.HessianSerializer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
 import net.afyer.afybroker.server.command.*;
@@ -29,13 +30,15 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Nipuru
  * @since 2022/7/29 20:13
  */
-public class BrokerServer {
+public class BrokerServer implements Attributable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServer.class);
 
@@ -69,6 +72,9 @@ public class BrokerServer {
     private final BrokerServiceRegistry serviceRegistry;
 
     private final PlayerHeartbeatValidateTask playerHeartbeatValidateTask;
+
+    /** 服务器全局属性 */
+    private final Map<String, byte[]> attributes = new ConcurrentHashMap<>();
 
     BrokerServer() throws IOException {
         this.terminal = TerminalBuilder.builder().system(true).jansi(true).build();
@@ -250,6 +256,26 @@ public class BrokerServer {
         if (object instanceof BrokerServerAware) {
             ((BrokerServerAware) object).setBrokerServer(this);
         }
+    }
+
+    @Override
+    public void setAttribute(String key, byte[] value) {
+        attributes.put(key, value);
+    }
+
+    @Override
+    public byte[] getAttribute(String key) {
+        return attributes.get(key);
+    }
+
+    @Override
+    public boolean hasAttribute(String key) {
+        return attributes.containsKey(key);
+    }
+
+    @Override
+    public byte[] removeAttribute(String key) {
+        return attributes.remove(key);
     }
 
     public static BrokerServerBuilder builder() {

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
@@ -123,7 +123,8 @@ public class BrokerServerBuilder {
                 .registerUserProcessor(new KickPlayerBrokerProcessor())
                 .registerUserProcessor(new PlayerProfilePropertyBrokerProcessor())
                 .registerUserProcessor(new RpcInvocationBrokerProcessor())
-                .registerUserProcessor(new CloseBrokerClientBrokerProcessor());
+                .registerUserProcessor(new CloseBrokerClientBrokerProcessor())
+                .registerUserProcessor(new AttributeBrokerProcessor());
     }
 
 

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/AttributeBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/AttributeBrokerProcessor.java
@@ -1,0 +1,66 @@
+package net.afyer.afybroker.server.processor;
+
+import com.alipay.remoting.BizContext;
+import com.alipay.remoting.rpc.protocol.SyncUserProcessor;
+import net.afyer.afybroker.core.Attributable;
+import net.afyer.afybroker.core.message.AttributeMessage;
+import net.afyer.afybroker.server.BrokerServer;
+import net.afyer.afybroker.server.aware.BrokerServerAware;
+import net.afyer.afybroker.server.proxy.BrokerPlayer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 属性操作处理器
+ * 统一处理 SET/GET/REMOVE/HAS 操作，支持 SERVER/PLAYER 两种作用域
+ *
+ * @author Conan-Wen
+ * @since 2026/3/22
+ */
+public class AttributeBrokerProcessor extends SyncUserProcessor<AttributeMessage> implements BrokerServerAware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AttributeBrokerProcessor.class);
+
+    private BrokerServer brokerServer;
+
+    @Override
+    public void setBrokerServer(BrokerServer brokerServer) {
+        this.brokerServer = brokerServer;
+    }
+
+    @Override
+    public Object handleRequest(BizContext bizCtx, AttributeMessage request) throws Exception {
+        Attributable target;
+        if (request.getScope() == AttributeMessage.SCOPE_SERVER) {
+            target = brokerServer;
+        } else {
+            BrokerPlayer player = brokerServer.getPlayer(request.getUniqueId());
+            if (player == null) {
+                LOGGER.warn("Player not found for attribute operation: {}", request.getUniqueId());
+                return null;
+            }
+            target = player;
+        }
+
+        switch (request.getAction()) {
+            case AttributeMessage.ACTION_SET:
+                target.setAttribute(request.getKey(), request.getValue());
+                return null;
+            case AttributeMessage.ACTION_GET:
+                return target.getAttribute(request.getKey());
+            case AttributeMessage.ACTION_REMOVE:
+                target.removeAttribute(request.getKey());
+                return null;
+            case AttributeMessage.ACTION_HAS:
+                return target.hasAttribute(request.getKey());
+            default:
+                LOGGER.warn("Unknown attribute action: {}", request.getAction());
+                return null;
+        }
+    }
+
+    @Override
+    public String interest() {
+        return AttributeMessage.class.getName();
+    }
+}

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/proxy/BrokerPlayer.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/proxy/BrokerPlayer.java
@@ -1,11 +1,14 @@
 package net.afyer.afybroker.server.proxy;
 
+import net.afyer.afybroker.core.Attributable;
 import net.afyer.afybroker.core.message.ConnectToServerMessage;
 import net.afyer.afybroker.core.message.KickPlayerMessage;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 玩家代理
@@ -13,7 +16,7 @@ import java.util.UUID;
  * @author Nipuru
  * @since 2022/7/30 16:47
  */
-public class BrokerPlayer {
+public class BrokerPlayer implements Attributable {
 
     /** 玩家UUID */
     private final UUID uniqueId;
@@ -21,6 +24,8 @@ public class BrokerPlayer {
     private final String name;
     /** 玩家所在的 Proxy 服务器客户端代理 */
     private final BrokerClientItem proxy;
+    /** 玩家属性 */
+    private final Map<String, byte[]> attributes = new ConcurrentHashMap<>();
 
     /** 玩家所在的 Minecraft 服务器客户端代理 */
     @Nullable
@@ -67,6 +72,28 @@ public class BrokerPlayer {
                 .setServerName(serverName);
 
         proxy.oneway(request);
+    }
+
+    @Override
+    public void setAttribute(String key, byte[] value) {
+        attributes.put(key, value);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getAttribute(String key) {
+        return attributes.get(key);
+    }
+
+    @Override
+    public boolean hasAttribute(String key) {
+        return attributes.containsKey(key);
+    }
+
+    @Nullable
+    @Override
+    public byte[] removeAttribute(String key) {
+        return attributes.remove(key);
     }
 
     @Override


### PR DESCRIPTION
## 概述

为 AfyBroker 添加基于内存的键值对属性系统，支持在不同 Minecraft 服务器之间传递静态信息。

- 支持**服务器全局属性**（存储在 BrokerServer）和**玩家属性**（存储在 BrokerPlayer）两种作用域
- 通过单一 `AttributeMessage` 消息类和单一处理器实现所有操作（SET/GET/REMOVE/HAS），最小化文件数量
- 值使用 Hessian 序列化为 `byte[]` 存储，Server 端完全类型无关
- 纯内存存储，无持久化

## 新增文件（3个）

| 文件 | 模块 | 说明 |
|------|------|------|
| `Attributable.java` | core | 属性化接口，定义 `setAttribute` / `getAttribute` / `hasAttribute` / `removeAttribute` |
| `AttributeMessage.java` | core/message | 统一属性操作消息，使用 `int` 常量区分 action（SET=0, GET=1, REMOVE=2, HAS=3）和 scope（SERVER=0, PLAYER=1） |
| `AttributeBrokerProcessor.java` | server/processor | 服务端属性处理器，`SyncUserProcessor` 实现，switch 分发所有操作 |

## 修改文件（5个）

| 文件 | 修改内容 |
|------|----------|
| `BrokerPlayer.java` | 实现 `Attributable` 接口，新增 `ConcurrentHashMap<String, byte[]>` 存储玩家属性 |
| `BrokerServer.java` | 实现 `Attributable` 接口，新增 `ConcurrentHashMap<String, byte[]>` 存储全局属性 |
| `BrokerServerBuilder.java` | 在 `defaultProcessor()` 中注册 `AttributeBrokerProcessor` |
| `BrokerClient.java` | 添加 8 个属性操作方法（set/get/remove/has × server/player），内部处理 Hessian 序列化 |
| `Broker.java`（客户端） | 添加 8 个静态代理方法 |
| `Broker.java`（服务端） | 添加 4 个服务器属性静态方法（直接操作，无需 RPC） |

## API 使用示例

### 客户端（Bukkit / BungeeCord / Velocity 插件）

```java
// ===== 服务器全局属性 =====
// 任何一个客户端设置，所有客户端都能读取
Broker.setServerAttribute("maintenance", true);
boolean maintenance = Broker.getServerAttribute("maintenance");
Broker.hasServerAttribute("maintenance");   // true
Broker.removeServerAttribute("maintenance");

// ===== 玩家属性 =====
UUID uuid = player.getUniqueId();
Broker.setPlayerAttribute(uuid, "party_id", "team_alpha");
String partyId = Broker.getPlayerAttribute(uuid, "party_id");
Broker.hasPlayerAttribute(uuid, "party_id");    // true
Broker.removePlayerAttribute(uuid, "party_id");
```

### 服务端（BrokerServer 插件）

```java
// 直接访问，无网络开销
Broker.setServerAttribute("key", serializedBytes);
byte[] value = Broker.getServerAttribute("key");

// 通过 BrokerPlayer 直接操作
BrokerPlayer player = Broker.getPlayer(uuid);
player.setAttribute("key", serializedBytes);
byte[] attr = player.getAttribute("key");
```

## 架构设计

### 数据流

```
Client 调用 Broker.setPlayerAttribute(uuid, "vip", 3)
  |
  |  1. Hessian 序列化: Integer(3) → byte[]
  |  2. 构建 AttributeMessage { action=SET, scope=PLAYER, uuid, key="vip", value=byte[] }
  |  3. invokeSync(message)
  ↓
BrokerServer - AttributeBrokerProcessor.handleRequest()
  |
  |  1. scope=PLAYER → playerManager.getPlayer(uuid)
  |  2. action=SET → brokerPlayer.setAttribute("vip", byte[])
  |  3. return null (成功)
  ↓
Client 调用 Broker.getPlayerAttribute(uuid, "vip")
  |
  |  1. 构建 AttributeMessage { action=GET, scope=PLAYER, uuid, key="vip" }
  |  2. invokeSync(message)
  ↓
BrokerServer 返回 byte[]
  |
  |  Client: Hessian 反序列化 byte[] → Integer(3)
  ↓
返回值: 3
```

### 消息设计（最小化文件数量）

传统做法需要 6 个消息类 + 6 个处理器 = 12 个文件。本实现通过单一消息类内置操作类型常量：

```java
public class AttributeMessage implements Serializable {
    // 操作类型 (int 常量，避免额外 enum 文件)
    public static final int ACTION_SET = 0;
    public static final int ACTION_GET = 1;
    public static final int ACTION_REMOVE = 2;
    public static final int ACTION_HAS = 3;

    // 作用域
    public static final int SCOPE_SERVER = 0;
    public static final int SCOPE_PLAYER = 1;

    private int action;
    private int scope;
    private String key;
    private byte[] value;       // 仅 SET 使用
    private UUID uniqueId;      // 仅 PLAYER 使用
}
```

**最终：1 个消息类 + 1 个处理器 = 2 个核心文件**

### 存储策略

- **存储格式**: `ConcurrentHashMap<String, byte[]>` — 值以 Hessian 序列化字节存储，Server 无需知道具体类型
- **线程安全**: `ConcurrentHashMap` 保证并发安全
- **生命周期**: 玩家属性随 `BrokerPlayer` 从 `BrokerPlayerManager` 移除而 GC；服务器属性随进程存在
- **无持久化**: 纯内存，重启后丢失

## 注意事项

1. **Bukkit 主线程限制**: `BukkitServerThreadPreprocessor` 会阻止在主线程调用 `invokeSync`，属性操作需在异步线程执行
2. **玩家不在线**: 对不在线玩家操作属性会返回 `null`
3. **值不可为 null**: SET 时传 null 值无意义，需要清除属性请使用 `remove`
4. **值类型**: 支持任何 Hessian 可序列化类型（基本类型、String、集合、自定义 Serializable 类等）