### PR TITLE
fix(server): handle graceful shutdown on SIGTERM

### DIFF
--- a/afybroker-server-bootstrap/src/main/java/net/afyer/afybroker/server/BootStrap.java
+++ b/afybroker-server-bootstrap/src/main/java/net/afyer/afybroker/server/BootStrap.java
@@ -21,6 +21,7 @@ public class BootStrap {
         BrokerServer brokerServer = BrokerServer.builder().build();
 
         Broker.setServer(brokerServer);
+        Runtime.getRuntime().addShutdownHook(new Thread(brokerServer::shutdownGracefully, "Broker Shutdown Hook"));
 
         brokerServer.startup();
         brokerServer.runConsoleLoop();

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServer.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServer.java
@@ -6,7 +6,6 @@ import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.rpc.RpcServer;
 import com.alipay.remoting.rpc.protocol.UserProcessor;
 import com.alipay.remoting.serialization.SerializerManager;
-import com.google.common.collect.Lists;
 import net.afyer.afybroker.core.Attributable;
 import net.afyer.afybroker.core.AttributeContainer;
 import net.afyer.afybroker.core.observability.Observability;
@@ -32,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -221,36 +222,67 @@ public class BrokerServer implements Attributable {
     }
 
     public void shutdown() {
+        shutdownGracefully();
+        System.exit(0);
+    }
+
+    public void shutdownGracefully() {
         synchronized (this) {
             if (!start) {
-                LOGGER.info("Server already closed");
+                logInfo("Server already closed");
                 return;
             }
             start = false;
-            LOGGER.info("Stopping the server");
-            new Thread("Shutdown Thread") {
-                @Override
-                public void run() {
-                    LOGGER.info("Stopping server");
-                    LOGGER.info("Disabling plugins");
-                    for (Plugin plugin : Lists.reverse(new ArrayList<>(pluginManager.getPlugins()))) {
-                        try {
-                            plugin.onDisable();
-                        } catch (Throwable t) {
-                            LOGGER.error("Exception disabling plugin {}", plugin.getDescription().getName(), t);
-                        }
-                        scheduler.cancel(plugin);
-                    }
-                    playerHeartbeatValidateTask.cancel();
-                    rpcServer.shutdown();
-                    try {
-                        terminal.close();
-                    } catch (IOException ignored) {
-                    }
-                    observability.close();
-                    System.exit(0);
+            logInfo("Stopping the server");
+            logInfo("Disabling plugins");
+            List<Plugin> plugins = new ArrayList<>(pluginManager.getPlugins());
+            Collections.reverse(plugins);
+            for (Plugin plugin : plugins) {
+                try {
+                    plugin.onDisable();
+                } catch (Throwable t) {
+                    logError("Exception disabling plugin " + plugin.getDescription().getName(), t);
                 }
-            }.start();
+                try {
+                    scheduler.cancel(plugin);
+                } catch (Throwable t) {
+                    logError("Exception cancelling tasks for plugin " + plugin.getDescription().getName(), t);
+                }
+            }
+            try {
+                playerHeartbeatValidateTask.cancel();
+            } catch (Throwable t) {
+                logError("Exception cancelling player heartbeat validation", t);
+            }
+            try {
+                rpcServer.shutdown();
+            } catch (Throwable t) {
+                logError("Exception shutting down rpc server", t);
+            }
+            try {
+                terminal.close();
+            } catch (Throwable t) {
+                logError("Exception closing terminal", t);
+            }
+            try {
+                observability.close();
+            } catch (Throwable t) {
+                logError("Exception closing observability", t);
+            }
+        }
+    }
+
+    private void logInfo(String message) {
+        try {
+            LOGGER.info(message);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void logError(String message, Throwable throwable) {
+        try {
+            LOGGER.error(message, throwable);
+        } catch (Throwable ignored) {
         }
     }
 

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
@@ -21,6 +21,9 @@ import java.util.*;
  */
 public class BrokerServerBuilder {
 
+    private static final String ENV_BROKER_HOST = "AFYBROKER_HOST";
+    private static final String ENV_BROKER_PORT = "AFYBROKER_PORT";
+
     /**
      * broker 地址
      */
@@ -46,6 +49,8 @@ public class BrokerServerBuilder {
     private final List<Observability> observabilityList = new ArrayList<>();
 
     BrokerServerBuilder() {
+        applyEnvironmentOverrides();
+
         // 初始化一些处理器
         defaultProcessor();
 
@@ -53,6 +58,18 @@ public class BrokerServerBuilder {
         // 开启 bolt 重连
         System.setProperty(Configs.CONN_MONITOR_SWITCH, "true");
         System.setProperty(Configs.CONN_RECONNECT_SWITCH, "true");
+    }
+
+    private void applyEnvironmentOverrides() {
+        String envHost = System.getenv(ENV_BROKER_HOST);
+        if (envHost != null && !envHost.trim().isEmpty()) {
+            this.host = envHost.trim();
+        }
+
+        String envPort = System.getenv(ENV_BROKER_PORT);
+        if (envPort != null && !envPort.trim().isEmpty()) {
+            this.port = Integer.parseInt(envPort.trim());
+        }
     }
 
     public BrokerServerBuilder host(String host) {


### PR DESCRIPTION
Adds graceful shutdown handling for broker server process termination.

When AfyBroker is deployed in Docker, stopping the container with `docker stop` or `docker compose stop` sends SIGTERM to the JVM. This change registers a shutdown hook so that container shutdown runs the same broker cleanup path as the console `stop` command.

The broker server builder also supports Docker-friendly bind configuration through environment variables while preserving the existing default `localhost:11200` behavior for normal launches.

- Register a JVM shutdown hook in the server bootstrap
- Reuse broker shutdown cleanup for console stop and SIGTERM
- Guard shutdown cleanup so logging failures do not block resource cleanup
- Avoid relying on Guava during JVM shutdown cleanup
- Allow `AFYBROKER_HOST` and `AFYBROKER_PORT` to override the broker bind address

For Docker deployments, setting `AFYBROKER_HOST=0.0.0.0` and `AFYBROKER_PORT=11200` lets other containers reach the broker service. Docker stop commands will still trigger the graceful shutdown cleanup path.
