### PR TITLE
fix: 保留连接事件处理器的 Broker 依赖注入

### DIFF
--- a/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClientBuilder.java
+++ b/afybroker-client/src/main/java/net/afyer/afybroker/client/BrokerClientBuilder.java
@@ -184,7 +184,7 @@ public class BrokerClientBuilder {
 
         processorList.forEach(brokerClient::aware);
         processorList.forEach(rpcClient::registerUserProcessor);
-        connectionEventTypeProcessorList.forEach(brokerClient::aware);
+        connectionEventTypeProcessorList.forEach(processor -> brokerClient.aware(processor.getDelegate()));
         connectionEventTypeProcessorList.forEach(processor -> rpcClient.addConnectionEventProcessor(processor.getType(), processor));
 
         return brokerClient;

--- a/afybroker-core/src/main/java/net/afyer/afybroker/core/util/ConnectionEventTypeProcessor.java
+++ b/afybroker-core/src/main/java/net/afyer/afybroker/core/util/ConnectionEventTypeProcessor.java
@@ -12,6 +12,15 @@ import com.alipay.remoting.ConnectionEventType;
 public interface ConnectionEventTypeProcessor extends ConnectionEventProcessor {
     ConnectionEventType getType();
 
+    /**
+     * Returns the processor that owns any broker-aware state.  Wrapping a
+     * ConnectionEventProcessor must not hide BrokerClientAware or
+     * BrokerServerAware from the builders' dependency injection step.
+     */
+    default Object getDelegate() {
+        return this;
+    }
+
     static ConnectionEventTypeProcessor wrap(ConnectionEventType type, ConnectionEventProcessor processor) {
         return new ConnectionEventTypeProcessor() {
             @Override
@@ -22,6 +31,11 @@ public interface ConnectionEventTypeProcessor extends ConnectionEventProcessor {
             @Override
             public ConnectionEventType getType() {
                 return type;
+            }
+
+            @Override
+            public Object getDelegate() {
+                return processor;
             }
         };
     }

--- a/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
+++ b/afybroker-server/src/main/java/net/afyer/afybroker/server/BrokerServerBuilder.java
@@ -96,6 +96,7 @@ public class BrokerServerBuilder {
         brokerServer.initServer();
 
         processorList.forEach(brokerServer::registerUserProcessor);
+        connectionEventTypeProcessorList.forEach(processor -> brokerServer.aware(processor.getDelegate()));
         connectionEventTypeProcessorList.forEach(processor -> brokerServer.addConnectionEventProcessor(processor.getType(), processor));
 
         return brokerServer;


### PR DESCRIPTION
## 背景与问题

`BrokerClientBuilder` 和 `BrokerServerBuilder` 会把 `ConnectionEventProcessor` 包装为 `ConnectionEventTypeProcessor`，以附加 Bolt 的 `ConnectionEventType`。

包装前的真实处理器可能实现 `BrokerClientAware` 或 `BrokerServerAware`，依赖构建器的 `aware(...)` 注入 Broker 实例。原实现把**包装器**传给 `aware(...)`：匿名包装器本身不实现这些 aware 接口，导致真实处理器的依赖注入被跳过。Server 端此前还完全没有为连接事件处理器执行 `aware(...)`。

这会使连接、断开、异常、重连等事件处理器在访问 Broker 状态时出现空依赖，并影响客户端重注册等恢复路径。

## 修改内容

1. 在 `ConnectionEventTypeProcessor` 增加默认方法 `getDelegate()`：
   - 直接实现该接口的处理器默认返回自身；
   - `wrap(type, processor)` 创建的包装器返回其内部真实 `processor`。
2. 在 `BrokerClientBuilder.build()` 中：
   - 对 `processor.getDelegate()` 执行 `brokerClient.aware(...)`；
   - 仍将包装器注册到 `RpcClient`，因此事件类型绑定与实际回调分派保持不变。
3. 在 `BrokerServerBuilder.build()` 中补齐对应的 `brokerServer.aware(processor.getDelegate())`，随后继续注册原包装器。

## 行为与兼容性

- 不改变 Bolt 连接事件、RPC 消息格式、序列化协议或路由语义。
- 不改变 `ConnectionEventTypeProcessor.wrap(...)` 对事件的转发行为。
- `getDelegate()` 是接口新增的 default 方法，对现有实现保持二进制与源代码兼容；若调用方自行实现包装器，可按需覆写。
- 修复后，真正持有 broker-aware 状态的事件处理器会在注册前得到正确的 `BrokerClient`/`BrokerServer` 注入。

## 验证

- `./gradlew --no-daemon :afybroker-client:test :afybroker-server:test`：成功。
  - 这两个模块当前没有测试源码，任务执行到编译与测试生命周期，结果为 `BUILD SUCCESSFUL`。
- 下游 HUA-215 Mineflayer 运行时验收：Broker 两次重启后，五个路由节点都重新注册，新的玩家仍可经 Velocity 登录并在 `general-lobby-1` spawn。

## 关联说明

下游部署同时对齐了 Broker、Bukkit 与 Velocity 的 AfyBroker JAR，以消除旧运行时与调用方之间的 `ClientRegisterEvent.getClient()` ABI 不匹配。本 PR 只包含本仓库的连接事件注入修复，不包含下游镜像、Docker 或 QA 产物。
